### PR TITLE
Use objects instead of classes.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -14,14 +14,14 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private def printAsScript(): Unit = {
     sb.println("package repl")
     sb.println("class Session {")
-    sb.println("  class App() {")
+    sb.println("  object App {")
     sections.zipWithIndex.foreach {
       case (section, j) =>
         if (j > i) ()
         else {
           if (section.mod == Modifier.Reset) {
-            val nextApp = gensym.fresh("App", "()")
-            sb.print(s"new $nextApp\n}\nclass $nextApp {\n")
+            val nextApp = gensym.fresh("App")
+            sb.print(s"$nextApp\n}\nobject $nextApp {\n")
           }
           if (j == i || section.mod != Modifier.Fail) {
             sb.println(section.input.text)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
@@ -19,8 +19,8 @@ class Instrumenter(sections: List[SectionInput]) {
     sections.zipWithIndex.foreach {
       case (section, i) =>
         if (section.mod == Modifier.Reset) {
-          val nextApp = gensym.fresh("App", "()")
-          sb.print(s"new $nextApp\n}\nclass $nextApp {\n")
+          val nextApp = gensym.fresh("App")
+          sb.print(s"$nextApp\n}\nobject $nextApp {\n")
         }
         sb.println("\n$doc.startSection();")
         if (section.mod == Modifier.Fail) {
@@ -96,9 +96,9 @@ object Instrumenter {
   def wrapBody(body: String): String = {
     val wrapped = new StringBuilder()
       .append("package repl\n")
-      .append("class Session extends _root_.mdoc.internal.document.DocumentBuilder {\n")
-      .append("  def app(): Unit = new App()\n")
-      .append("  class App {\n")
+      .append("object Session extends _root_.mdoc.internal.document.DocumentBuilder {\n")
+      .append("  def app(): Unit = App\n")
+      .append("  object App {\n")
       .append(body)
       .append("  }\n")
       .append("}\n")

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -42,8 +42,10 @@ object MarkdownCompiler {
     val edit = TokenEditDistance.toTokenEdit(sectionInputs.map(_.source), compileInput)
     val doc = compiler.compile(compileInput, reporter, edit) match {
       case Some(loader) =>
-        val cls = loader.loadClass("repl.Session")
-        val doc = cls.newInstance().asInstanceOf[DocumentBuilder].$doc
+        val cls = loader.loadClass("repl.Session$")
+        val ctor = cls.getDeclaredConstructor()
+        ctor.setAccessible(true)
+        val doc = ctor.newInstance().asInstanceOf[DocumentBuilder].$doc
         try {
           doc.build(instrumentedInput)
         } catch {

--- a/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
@@ -44,4 +44,28 @@ class ScalacOptionsSuite extends BaseCliSuite {
     """.stripMargin
   )
 
+  // NOTE(olafur): with -Xfatal-warning, the following program reports the following
+  // warning if its wrapped in classes.
+  // > warning: The outer reference in this type test cannot be checked at run time.
+  // We wrap the code in objects instead of classes to avoid this warning.
+  val finalInput: String =
+    """
+      |/in.md
+      |```scala mdoc
+      |sealed abstract class Maybe[+A] extends Product with Serializable
+      |
+      |final case class Just[A](value: A) extends Maybe[A]
+      |final case object Nothing extends Maybe[Nothing]
+      |```
+    """.stripMargin
+  checkCli(
+    "final",
+    finalInput,
+    extraArgs = Array(
+      "--scalac-options",
+      "-Ywarn-unused -Xfatal-warnings"
+    ),
+    expected = finalInput.replaceFirst("scala mdoc", "scala")
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -15,7 +15,7 @@ class CrashSuite extends BaseMarkdownSuite {
       |???
       |// scala.NotImplementedError: an implementation is missing
       |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-      |// 	at repl.Session$App.$anonfun$new$2(basic.md:14)
+      |// 	at repl.Session$App$.$anonfun$new$2(basic.md:14)
       |```
     """.stripMargin
   )
@@ -62,7 +62,7 @@ class CrashSuite extends BaseMarkdownSuite {
        |  case 2 => // boom!
        |}
        |// scala.MatchError: 1 (of class java.lang.Integer)
-       |// 	at repl.Session$App.$anonfun$new$1(comments.md:9)
+       |// 	at repl.Session$App$.$anonfun$new$1(comments.md:9)
        |```
     """.stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
@@ -21,10 +21,11 @@ class ErrorSuite extends BaseMarkdownSuite {
        |^^^^^^^^^
        |scala.NotImplementedError: an implementation is missing
        |	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-       |	at repl.Session$App.crash(crash.md:17)
-       |	at repl.Session$App.z(crash.md:20)
-       |	at repl.Session$App.<init>(crash.md:26)
-       |	at repl.Session.app(crash.md:3)
+       |	at repl.Session$App$.crash(crash.md:17)
+       |	at repl.Session$App$.z(crash.md:20)
+       |	at repl.Session$App$.<init>(crash.md:26)
+       |	at repl.Session$App$.<clinit>(crash.md)
+       |	at repl.Session$.app(crash.md:3)
        |""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -185,7 +185,11 @@ class FailSuite extends BaseMarkdownSuite {
        |println(a)
        |println(b)
        |// error: not found: value a
+       |// println(a)
+       |//         ^
        |// error: not found: value b
+       |// println(b)
+       |//         ^
        |```
        |
        |```scala


### PR DESCRIPTION
With classes, we get the following warning when declaring sealed ADTs:

```
warning: The outer reference in this type test cannot be checked at run time.
```

Previously, we wrapped the code in `class Session { class App { ... } }`.
Now, we wrap the code in `object Session { object App { ... } }`
instead, which removes the warning. Interestingly, this change improved
error reporting for `:fail` in one test case where I was unhappy with
the old behavior.

Reported on Gitter https://gitter.im/scalameta/mdoc?at=5c293ede0b7fc97caac3f794

Thanks @nrinaudo for reporting!