### PR TITLE
Use relative filenames in crash stacktraces.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -125,8 +125,10 @@ class MarkdownCompiler(
     case _ =>
   }
 
-  private def toSource(input: Input): BatchSourceFile =
-    new BatchSourceFile(input.syntax, new String(input.chars))
+  private def toSource(input: Input): BatchSourceFile = {
+    val filename = Paths.get(input.syntax).getFileName.toString
+    new BatchSourceFile(filename, new String(input.chars))
+  }
 
   def fail(original: Seq[Tree], input: Input): String = {
     sreporter.reset()

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -67,4 +67,20 @@ class CrashSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  check(
+    "path/to/relative",
+    """
+      |```scala mdoc:crash
+      |???
+      |```
+    """.stripMargin,
+    """|```scala
+       |???
+       |// scala.NotImplementedError: an implementation is missing
+       |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
+       |// 	at repl.Session$App$.$anonfun$new$1(relative.md:9)
+       |```
+    """.stripMargin
+  )
+
 }


### PR DESCRIPTION
Fixes #81.