### PR TITLE
Add support for multiple modifiers.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -19,11 +19,11 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
       case (section, j) =>
         if (j > i) ()
         else {
-          if (section.mod == Modifier.Reset) {
+          if (section.mod.isReset) {
             val nextApp = gensym.fresh("App")
             sb.print(s"$nextApp\n}\nobject $nextApp {\n")
           }
-          if (j == i || section.mod != Modifier.Fail) {
+          if (j == i || !section.mod.isFail) {
             sb.println(section.input.text)
           }
         }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Mod.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Mod.scala
@@ -1,0 +1,23 @@
+package mdoc.internal.markdown
+
+sealed abstract class Mod extends Product with Serializable
+object Mod {
+  case object Fail extends Mod
+  case object Crash extends Mod
+  case object Silent extends Mod
+  case object Passthrough extends Mod
+  case object Invisible extends Mod
+  case object Reset extends Mod
+
+  def all: List[Mod] = List(
+    Passthrough,
+    Invisible,
+    Reset,
+    Fail,
+    Crash,
+    Silent
+  )
+  def unapply(string: String): Option[Mod] = {
+    all.find(_.toString.equalsIgnoreCase(string))
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -25,7 +25,7 @@ object Renderer {
       printer: Variable => String
   ): String = {
     val inputs =
-      sections.map(s => SectionInput(s, dialects.Sbt1(s).parse[Source].get, Modifier.Default))
+      sections.map(s => SectionInput(s, dialects.Sbt1(s).parse[Source].get, Modifier.Default()))
     val instrumented = Instrumenter.instrument(inputs)
     val doc =
       MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented, filename)
@@ -129,7 +129,7 @@ object Renderer {
         statement.binders.zipWithIndex.foreach {
           case (binder, i) =>
             section.mod match {
-              case Modifier.Fail =>
+              case Modifier.Fail() =>
                 sb.append('\n')
                 binder.value match {
                   case FailSection(instrumented, startLine, startColumn, endLine, endColumn) =>
@@ -149,7 +149,7 @@ object Renderer {
                       s"Expected FailSection. Obtained $obtained"
                     )
                 }
-              case Modifier.Default | Modifier.Passthrough | Modifier.Reset | Modifier.Post(_, _) =>
+              case Modifier.PrintVariable() | Modifier.Post(_, _) =>
                 val pos = binder.pos.toMeta(section)
                 val variable = new mdoc.Variable(
                   binder.name,
@@ -162,8 +162,7 @@ object Renderer {
                   totalStats
                 )
                 sb.append(printer(variable))
-              case c @ (Modifier.Str(_, _) | Modifier.Silent | Modifier.Invisible |
-                  Modifier.Crash) =>
+              case c @ (Modifier.Str(_, _) | Modifier.Builtin(_)) =>
                 throw new IllegalArgumentException(c.toString)
             }
         }

--- a/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
@@ -114,4 +114,17 @@ class ErrorSuite extends BaseMarkdownSuite {
        |          ^^^^^^^^^^^^^^^^^^
     """.stripMargin
   )
+
+  checkError(
+    "multimods-typo",
+    """
+      |```scala mdoc:reset:silen
+      |List[Int]("".length.toString)
+      |```
+    """.stripMargin,
+    """|error: multimods-typo.md:2:15: error: Invalid mode 'reset:silen'
+       |```scala mdoc:reset:silen
+       |              ^^^^^^^^^^^
+    """.stripMargin
+  )
 }

--- a/tests/unit/src/test/scala/tests/markdown/MultiModsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MultiModsSuite.scala
@@ -1,0 +1,105 @@
+package tests.markdown
+
+class MultiModsSuite extends BaseMarkdownSuite {
+
+  check(
+    "reset:fail",
+    """
+      |```scala mdoc
+      |val x = 1
+      |```
+      |
+      |```scala mdoc:reset:fail
+      |println(x)
+      |```
+    """.stripMargin,
+    """|```scala
+       |val x = 1
+       |// x: Int = 1
+       |```
+       |
+       |```scala
+       |println(x)
+       |// error: not found: value x
+       |// println(x)
+       |//         ^
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "reset:silent",
+    """
+      |```scala mdoc
+      |val x = 1
+      |```
+      |
+      |```scala mdoc:reset:silent
+      |val x = 1
+      |```
+    """.stripMargin,
+    """|```scala
+       |val x = 1
+       |// x: Int = 1
+       |```
+       |
+       |```scala
+       |val x = 1
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "reset:invisible",
+    """
+      |```scala mdoc
+      |val x = 1
+      |```
+      |
+      |```scala mdoc:reset:invisible
+      |val x = 2
+      |```
+      |
+      |```scala mdoc
+      |println(x)
+      |```
+    """.stripMargin,
+    """|```scala
+       |val x = 1
+       |// x: Int = 1
+       |```
+       |
+       |```scala
+       |println(x)
+       |// 2
+       |```
+    """.stripMargin
+  )
+
+  checkError(
+    "silent:invisible",
+    """
+      |```scala mdoc:reset:silent:invisible
+      |val x = 2
+      |```
+    """.stripMargin,
+    """|error: silent:invisible.md:2:15: error: invalid combination of modifiers 'silent' and 'invisible' are
+       |```scala mdoc:reset:silent:invisible
+       |              ^^^^^^^^^^^^^^^^^^^^^^
+    """.stripMargin
+  )
+
+  checkError(
+    "fail:crash",
+    """
+      |```scala mdoc:reset:fail:crash
+      |val x = 2
+      |```
+    """.stripMargin,
+    """|error: fail:crash.md:2:15: error: invalid combination of modifiers 'crash' and 'fail' are
+       |```scala mdoc:reset:fail:crash
+       |              ^^^^^^^^^^^^^^^^
+    """.stripMargin
+  )
+
+}


### PR DESCRIPTION
Fixes #119.

Previously, it was only possible to provide one modifier for each code
fence making it impossible to for example write:

````md
```scala mdoc:reset:silent
```
````

This commit refactors the internals to support multiple builtin
modifiers for each code fence.