### PR TITLE
Improve handling of futures

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
@@ -38,7 +38,7 @@ class ConsoleReporter(
   }
 
   def error(pos: Position, throwable: Throwable): Unit = {
-    error(pos, throwable.getMessage)
+    error(pos, throwable.message)
     throwable.printStackTrace(ps)
   }
   def error(pos: Position, msg: String): Unit = {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -11,6 +11,7 @@ import mdoc.Reporter
 import mdoc.document.Document
 import mdoc.document._
 import mdoc.internal.document.DocumentBuilder
+import mdoc.internal.document.MdocNonFatal
 import mdoc.internal.pos.PositionSyntax
 import mdoc.internal.pos.PositionSyntax._
 import mdoc.internal.pos.TokenEditDistance
@@ -66,6 +67,9 @@ object MarkdownCompiler {
               }
             reporter.error(pos, e.getCause)
             Document.empty(instrumentedInput)
+          case MdocNonFatal(e) =>
+            reporter.error(e)
+            Document.empty(instrumentedInput)
         }
       case None =>
         // An empty document will render as the original markdown
@@ -108,6 +112,10 @@ class MarkdownCompiler(
   settings.unchecked.value = true // enable detailed unchecked warnings
   settings.outputDirs.setSingleOutput(target)
   settings.classpath.value = classpath
+  // enable -Ydelambdafy:inline to avoid future timeouts, see:
+  //   https://github.com/scala/bug/issues/9824
+  //   https://github.com/scalameta/mdoc/issues/124
+  settings.Ydelambdafy.value = "inline"
   settings.processArgumentString(scalacOptions)
 
   private val sreporter = new FilterStoreReporter(settings)

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -153,4 +153,11 @@ object PositionSyntax {
     }
   }
 
+  implicit class XtensionThrowable(e: Throwable) {
+    def message: String = {
+      if (e.getMessage != null) e.getMessage
+      else if (e.getCause != null) e.getCause.message
+      else "null"
+    }
+  }
 }

--- a/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
@@ -2,12 +2,12 @@ package mdoc.internal.document
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import mdoc.document._
 import pprint.TPrint
 import scala.collection.mutable.ArrayBuffer
 import scala.language.experimental.macros
 import scala.util.control.NonFatal
 import sourcecode.Text
-import mdoc.document._
 
 trait DocumentBuilder {
 
@@ -77,7 +77,7 @@ trait DocumentBuilder {
           }
         }
       } catch {
-        case NonFatal(e) =>
+        case MdocNonFatal(e) =>
           MdocExceptions.trimStacktrace(e)
           throw new PositionedException(mySections.length, lastPosition, e)
       }

--- a/runtime/src/main/scala/mdoc/internal/document/MdocExceptions.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/MdocExceptions.scala
@@ -1,0 +1,21 @@
+package mdoc.internal.document
+
+import java.util.Collections
+import scala.annotation.tailrec
+
+object MdocExceptions {
+  def trimStacktrace(e: Throwable): Unit = {
+    val isVisited =
+      Collections.newSetFromMap(new java.util.IdentityHashMap[Throwable, java.lang.Boolean])
+    @tailrec def loop(ex: Throwable): Unit = {
+      isVisited.add(ex)
+      val stacktrace = ex.getStackTrace.takeWhile(!_.getClassName.startsWith("mdoc"))
+      ex.setStackTrace(stacktrace)
+      // avoid infinite loop when traversing exceptions cyclic dependencies between causes.
+      if (e.getCause != null && !isVisited.contains(e.getCause)) {
+        loop(e.getCause)
+      }
+    }
+    loop(e)
+  }
+}

--- a/runtime/src/main/scala/mdoc/internal/document/MdocNonFatal.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/MdocNonFatal.scala
@@ -1,0 +1,13 @@
+package mdoc.internal.document
+
+import scala.util.control.NonFatal
+
+object MdocNonFatal {
+  def unapply(e: Throwable): Option[Throwable] = e match {
+    case NonFatal(_) => Some(e)
+    // This exception happens when a val of an object fails to initialize,
+    // which can happen for any val in an mdoc code fence.
+    case _: ExceptionInInitializerError => Some(e)
+    case _ => None
+  }
+}

--- a/runtime/src/main/scala/mdoc/internal/document/mdocExceptions.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/mdocExceptions.scala
@@ -1,8 +1,0 @@
-package mdoc.internal.document
-
-object MdocExceptions {
-  def trimStacktrace(e: Throwable): Unit = {
-    val stacktrace = e.getStackTrace.takeWhile(!_.getClassName.startsWith("mdoc"))
-    e.setStackTrace(stacktrace)
-  }
-}

--- a/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
@@ -1,0 +1,51 @@
+package tests.markdown
+
+import java.util.concurrent.Executors
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class AsyncSuite extends BaseMarkdownSuite {
+  check(
+    "await",
+    """
+      |```scala mdoc
+      |import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+      |Await.result(Future(1), Duration("500ms"))
+      |```
+    """.stripMargin,
+    """|```scala
+       |import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+       |Await.result(Future(1), Duration("500ms"))
+       |// res0: Int = 1
+       |```
+    """.stripMargin
+  )
+
+  checkError(
+    "timeout",
+    """
+      |```scala mdoc
+      |import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+      |Await.result(Future(Thread.sleep(1000)), Duration("10ms"))
+      |```
+    """.stripMargin,
+    """|error: timeout.md:4:1: error: Futures timed out after [10 milliseconds]
+       |Await.result(Future(Thread.sleep(1000)), Duration("10ms"))
+       |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |java.lang.ExceptionInInitializerError
+       |	at repl.Session$.app(timeout.md:3)
+       |Caused by: java.util.concurrent.TimeoutException: Futures timed out after [10 milliseconds]
+       |	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259)
+       |	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:263)
+       |	at scala.concurrent.Await$.$anonfun$result$1(package.scala:219)
+       |	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:57)
+       |	at scala.concurrent.Await$.result(package.scala:146)
+       |	at repl.Session$App$.<init>(timeout.md:11)
+       |	at repl.Session$App$.<clinit>(timeout.md)
+       |	... 1 more
+    """.stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -9,14 +9,14 @@ class CrashSuite extends BaseMarkdownSuite {
       |???
       |```
     """.stripMargin,
-    """
-      |```scala
-      |val x = 1
-      |???
-      |// scala.NotImplementedError: an implementation is missing
-      |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-      |// 	at repl.Session$App$.$anonfun$new$2(basic.md:14)
-      |```
+    """|```scala
+       |val x = 1
+       |???
+       |// scala.NotImplementedError: an implementation is missing
+       |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
+       |// 	at repl.Session$App$$anonfun$2.apply(basic.md:14)
+       |// 	at repl.Session$App$$anonfun$2.apply(basic.md:14)
+       |```
     """.stripMargin
   )
 
@@ -62,7 +62,7 @@ class CrashSuite extends BaseMarkdownSuite {
        |  case 2 => // boom!
        |}
        |// scala.MatchError: 1 (of class java.lang.Integer)
-       |// 	at repl.Session$App$.$anonfun$new$1(comments.md:9)
+       |// 	at repl.Session$App$$anonfun$1.apply(comments.md:9)
        |```
     """.stripMargin
   )
@@ -78,7 +78,8 @@ class CrashSuite extends BaseMarkdownSuite {
        |???
        |// scala.NotImplementedError: an implementation is missing
        |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-       |// 	at repl.Session$App$.$anonfun$new$1(relative.md:9)
+       |// 	at repl.Session$App$$anonfun$1.apply(relative.md:9)
+       |// 	at repl.Session$App$$anonfun$1.apply(relative.md:9)
        |```
     """.stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/ExceptionSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ExceptionSuite.scala
@@ -1,0 +1,16 @@
+package tests.markdown
+
+import mdoc.internal.document.MdocExceptions
+import org.scalatest.FunSuite
+
+class ExceptionSuite extends FunSuite {
+  test("cyclic") {
+    var e1Cause: Throwable = null
+    val e1 = new Exception {
+      override def getCause: Throwable = e1Cause
+    }
+    val e2 = new Exception(e1)
+    e1Cause = e2
+    MdocExceptions.trimStacktrace(e1)
+  }
+}


### PR DESCRIPTION
Fixes #124

- enable -Ydelamdafy:inline by default to avoid future timeouts
- handle exceptions with null messages by delegating to cause if any, or
  falling back to the message "null".
- trim stacktrace of all exceptions, also causes.
- catch initialization exceptions in addition to `NonFatal`, since they
  happen when vals in mdoc code fences crash.