### PR TITLE
Add mdoc:js modifier for Scala.js integration.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -146,7 +146,7 @@ Use `--in` to customize the input directory where markdown sources are
 contained, by default the `docs/` directory is used.
 
 ```diff
- coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
+ coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ -- \
 +  --in mydocs
 ```
 
@@ -154,7 +154,7 @@ Use `--site.VARIABLE=value` to add site variables that can be referenced from
 markdown as `@@VARIABLE@`.
 
 ```diff
- coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
+ coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ -- \
 +  --site.SCALA_VERSION @SCALA_VERSION@
 ```
 
@@ -162,7 +162,7 @@ Use `--out` to customize the directory where markdown sources are generated, by
 default the `out/` directory is used.
 
 ```diff
- coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
+ coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ -- \
 +  --out target/docs
 ```
 
@@ -171,7 +171,7 @@ Use `--watch` to start the file watcher with livereload. It's recommended to use
 performance.
 
 ```diff
- coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
+ coursier launch org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ -- \
 +  --watch
 ```
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -1,0 +1,193 @@
+---
+id: js
+title: Scala.js
+---
+
+Use the `mdoc:js` modifier to write dynamic and interactive documentation with
+Scala.js.
+
+```scala mdoc:js
+Loading...
+---
+val tick = { () =>
+  val date = new scala.scalajs.js.Date()
+  val time = s"${date.getHours}h${date.getMinutes}m${date.getSeconds}s"
+  node.innerHTML = s"Current time is $time"
+}
+tick()
+org.scalajs.dom.window.setInterval(tick, 1000)
+```
+
+Code fences with the `mdoc:js` modifier compile to JavaScript and evaluate at
+HTML load time instead of at markdown generation time.
+
+Each `mdoc:js` code fence has access to a variable `node`, which is an empty DOM
+element.
+
+## Installation
+
+The `mdoc:js` modifier requires custom installation steps.
+
+### sbt-mdoc
+
+First, install sbt-mdoc using the
+[regular installation instructions](installation.md#sbt).
+
+Next, update the `mdocJS` setting to point to a Scala.js project that has
+`scalajs-dom` as a library dependency.
+
+```diff
+// build.sbt
+lazy val jsapp = project
+  .settings(
++   libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6"
+  )
+  .enablePlugins(ScalaJSPlugin)
+lazy val docs = project
+  .in(file("myproject-docs"))
+  .settings(
++   mdocJS := Some(jsapp)
+  )
+  .enablePlugins(MdocPlugin)
+```
+
+### Command-line
+
+First add a dependency on the `org.scalameta:mdoc-js` library.
+
+```diff
+ coursier launch \
+     org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
++    org.scalameta:mdoc-js_@SCALA_BINARY_VERSION@:@VERSION@
+```
+
+This dependency enables the `mdoc:js` modifier which requires the site variables
+`js-classpath` and `js-scalacOptions`.
+
+```diff
+ coursier launch \
+     org.scalameta:mdoc_@SCALA_BINARY_VERSION@:@VERSION@ \
+     org.scalameta:mdoc-js_@SCALA_BINARY_VERSION@:@VERSION@ -- \
++  --site.js-classpath CLASSPATH_OF_SCALAJS_PROJECT
++  --site.js-scalacOption OPTIONS_OF_SCALAJS_PROJECT
+```
+
+- `js-scalacOptions` must contain `-Xplugin:path/to/scalajs-compiler.jar` to
+  enable the Scala.js compiler. - `js-classpath` value must include a dependency
+  on the library `org.scala-js:scalajs-dom`
+
+## Modifiers
+
+The following modifiers can be combined with `mdoc:js` code fences to customize
+the rendered output.
+
+### `:shared`
+
+By default, each code fence is isolated from other code fences. Use the
+`:shared` modifier to reuse imports or variables between code fences.
+
+```scala mdoc:js:shared:invisible
+import org.scalajs.dom.window.setInterval
+import scala.scalajs.js.Date
+```
+
+````scala mdoc:mdoc
+```scala mdoc:js:shared
+import org.scalajs.dom.window.setInterval
+import scala.scalajs.js.Date
+```
+```scala mdoc:js
+setInterval(() => {
+  node.innerHTML = new Date().toString()
+}, 1000)
+```
+````
+
+```scala mdoc:js
+Loading <code>:shared</code> example...
+---
+setInterval(() => {
+  val date = new Date().toString()
+  node.innerHTML = s"Shared date $date"
+}, 1000)
+```
+
+Without `:shared`, the example above results in a compile error.
+
+````scala mdoc:mdoc:crash
+```scala mdoc:js
+import scala.scalajs.js.Date
+```
+```scala mdoc:js
+new Date()
+```
+````
+
+### `:invisible`
+
+By default, the original input code is rendered in the output page. Use
+`:invisible` to hide the code example from the output so that only the div is
+generated.
+
+````scala mdoc:mdoc
+```scala mdoc:js:invisible
+var n = 0
+org.scalajs.dom.window.setInterval(() => {
+  n += 1
+  node.innerHTML = s"Invisible tick: $n"
+}, 1000)
+```
+````
+
+```scala mdoc:js:invisible
+Loading <code>:invisible</code> example...
+---
+var n = 0
+setInterval(() => {
+  n += 1
+  node.innerHTML = s"Invisible tick: ${n}"
+}, 1000)
+```
+
+## Loading HTML
+
+By default, the `node` variable points to an empty div element. Prefix the code
+fence with custom HTML followed by a `---` separator to set the inner HTML of
+the `node` div.
+
+````scala mdoc:mdoc
+```scala mdoc:js
+<p>I am a custom <code>loader</code></p>
+---
+println(node.innerHTML)
+```
+````
+
+```scala mdoc:js
+<p>I am a custom <code>loader</code></p>
+---
+println(node.innerHTML) // Open developer console to see this printed message
+```
+
+Replace the node's `innerHTML` to make the HTML disappear once the document has
+loaded.
+
+```scala mdoc:js
+I disappear in 3 seconds...
+---
+org.scalajs.dom.window.setTimeout(() => {
+ node.innerHTML = "I am loaded. Refresh the page to load me again."
+}, 3000)
+```
+
+## Generate optimized page
+
+The Scala.js `fullOpt` mode is used by default and the `fastOpt` mode is used
+when the `-w` or `--watch` flag is used. The `fastOpt` mode provides faster
+feedback while iterating on documentation at the cost of larger bundle size and
+slower code. When publishing a website, the optimized mode should be used.
+
+Update the `js-opt` site variables to override the default optimization mode:
+
+- `js-opt=full`: use `fullOpt` regardless of watch mode
+- `js-opt=fast`: use `fastOpt` regardless of watch mode

--- a/mdoc-docs/src/main/scala/mdoc/docs/Docs.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/Docs.scala
@@ -1,7 +1,6 @@
 package mdoc.docs
 
 import java.nio.file.FileSystems
-import java.nio.file.Paths
 import scala.meta.internal.io.PathIO
 import mdoc.Main
 import mdoc.MainSettings

--- a/mdoc-docs/src/main/scala/mdoc/docs/SbtModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/SbtModifier.scala
@@ -15,6 +15,7 @@ class SbtModifier extends StringModifier {
       mdocOut,
       mdocVariables,
       mdocExtraArguments,
+      mdocJS,
       mdocAutoDependency
     )
     val rows = keys.map { s =>

--- a/mdoc-js/src/main/resources/META-INF/services/mdoc.PreModifier
+++ b/mdoc-js/src/main/resources/META-INF/services/mdoc.PreModifier
@@ -1,0 +1,1 @@
+mdoc.modifiers.JsModifier

--- a/mdoc-js/src/main/resources/mdoc.js
+++ b/mdoc-js/src/main/resources/mdoc.js
@@ -1,0 +1,12 @@
+(function(global) {
+  var dom = global.document;
+
+  function findDivs() {
+    return Array.from(dom.querySelectorAll("div[data-mdoc-js]"));
+  }
+
+  findDivs().forEach(function(el) {
+    var id = el.getAttribute("id");
+    window[id](el);
+  });
+})(window);

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -1,0 +1,255 @@
+package mdoc.modifiers
+
+import com.ibm.icu.text.RelativeDateTimeFormatter.RelativeDateTimeUnit
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import mdoc.OnLoadContext
+import mdoc.PostProcessContext
+import mdoc.PreModifierContext
+import mdoc.internal.cli.Timer
+import mdoc.internal.io.ConsoleReporter
+import mdoc.internal.livereload.Resources
+import mdoc.internal.markdown.CodeBuilder
+import mdoc.internal.markdown.Gensym
+import mdoc.internal.markdown.MarkdownCompiler
+import mdoc.internal.pos.TokenEditDistance
+import org.scalajs.core.tools.io.IRFileCache
+import org.scalajs.core.tools.io.IRFileCache.VirtualRelativeIRFile
+import org.scalajs.core.tools.io.MemVirtualSerializedScalaJSIRFile
+import org.scalajs.core.tools.io.VirtualScalaJSIRFile
+import org.scalajs.core.tools.io.WritableMemVirtualJSFile
+import mdoc.internal.pos.PositionSyntax._
+import org.scalajs.core.tools.linker.Linker
+import org.scalajs.core.tools.linker.StandardLinker
+import org.scalajs.core.tools.logging.Level
+import org.scalajs.core.tools.logging.Logger
+import org.scalajs.core.tools.sem.Semantics
+import scala.collection.mutable.ListBuffer
+import scala.meta.Term
+import scala.meta.inputs.Input
+import scala.meta.internal.io.PathIO
+import scala.meta.io.AbsolutePath
+import scala.meta.io.Classpath
+import scala.meta.io.RelativePath
+import scala.reflect.io.VirtualDirectory
+
+class JsModifier extends mdoc.PreModifier {
+  override val name = "js"
+  val irCache = new IRFileCache
+  val target = new VirtualDirectory("(memory)", None)
+  var mountNode = "node"
+  var maybeCompiler: Option[MarkdownCompiler] = None
+  var linker: Linker = newLinker()
+  var virtualIrFiles: Seq[VirtualRelativeIRFile] = Nil
+  var classpathHash: Int = 0
+  var reporter: mdoc.Reporter = new ConsoleReporter(System.out)
+  var gensym = new Gensym()
+  var outDirectory: AbsolutePath = PathIO.workingDirectory
+  var fullOpt = false
+  var minLevel: Level = Level.Info
+  val sjsLogger: Logger = new Logger {
+    override def log(level: Level, message: => String): Unit = {
+      if (level >= minLevel) {
+        if (level == Level.Warn) reporter.info(message)
+        else if (level == Level.Error) reporter.info(message)
+        else reporter.info(message)
+      }
+    }
+    override def success(message: => String): Unit =
+      reporter.info(message)
+    override def trace(t: => Throwable): Unit =
+      reporter.error(t)
+  }
+
+  private val runs = ListBuffer.empty[String]
+  private val inputs = ListBuffer.empty[Input]
+
+  def reset(): (List[String], List[Input]) = {
+    val result = (runs.toList, inputs.toList)
+    runs.clear()
+    inputs.clear()
+    gensym.reset()
+    result
+  }
+
+  def newLinker(): Linker = {
+    val semantics =
+      if (fullOpt) Semantics.Defaults.optimized
+      else Semantics.Defaults
+    StandardLinker(
+      StandardLinker
+        .Config()
+        .withSemantics(semantics)
+        .withSourceMap(false)
+        .withClosureCompilerIfAvailable(fullOpt)
+    )
+  }
+
+  override def onLoad(ctx: OnLoadContext): Unit = {
+    (ctx.site.get("js-classpath"), ctx.site.get("js-scalacOptions")) match {
+      case (None, None) => // nothing to do
+      case (Some(_), None) =>
+        ctx.reporter.error("missing key: 'js-scalacOptions'")
+      case (None, Some(_)) =>
+        ctx.reporter.error("missing key: 'js-classpath'")
+      case (Some(classpath), Some(scalacOptions)) =>
+        fullOpt = ctx.site.get("js-opt") match {
+          case None =>
+            !ctx.settings.watch
+          case Some(value) =>
+            value match {
+              case "fast" => false
+              case "full" => true
+              case unknown =>
+                ctx.reporter.error(s"unknown 'js-opt': $unknown")
+                !ctx.settings.watch
+            }
+        }
+        val newClasspathHash = (classpath, scalacOptions, fullOpt).hashCode()
+        // Reuse the  linker and compiler when the classpath+scalacOptions haven't changed
+        // to speed up unit tests by nearly 2x.
+        if (classpathHash != newClasspathHash) {
+          linker = newLinker()
+          classpathHash = newClasspathHash
+          maybeCompiler = Some(new MarkdownCompiler(classpath, scalacOptions, target))
+          virtualIrFiles = {
+            val irContainer =
+              IRFileCache.IRContainer.fromClasspath(Classpath(classpath).entries.map(_.toFile))
+            val cache = irCache.newCache
+            cache.cached(irContainer)
+          }
+        }
+        mountNode = ctx.site.getOrElse("js-mountNode", mountNode)
+        outDirectory = ctx.site.get("js-out-prefix") match {
+          case Some(value) =>
+            // This is needed for Docusaurus that requires assets (non markdown) files to live under
+            // `docs/assets/`: https://docusaurus.io/docs/en/doc-markdown#linking-to-images-and-other-assets
+            ctx.settings.out.resolve(value)
+          case None =>
+            ctx.settings.out
+        }
+        reporter = ctx.reporter
+        minLevel = ctx.site.get("js-level") match {
+          case None => Level.Info
+          case Some("info") => Level.Info
+          case Some("warn") => Level.Warn
+          case Some("error") => Level.Error
+          case Some("debug") => Level.Debug
+          case Some(unknown) =>
+            reporter.warning(s"unknown 'js-level': $unknown")
+            Level.Info
+        }
+    }
+  }
+
+  override def postProcess(ctx: PostProcessContext): String = {
+    if (runs.isEmpty) {
+      reset()
+      ""
+    } else {
+      maybeCompiler match {
+        case None =>
+          ctx.reporter.error(
+            inputs.head.toPosition,
+            "Can't process `mdoc:js` code fence because Scala.js is not configured. " +
+              "To fix this problem, set the site variables `js-classpath` and `js-scalacOptions`. " +
+              "If you are using sbt-mdoc, update the `mdocJS` setting to point to a Scala.js project."
+          )
+          ""
+        case Some(compiler) =>
+          postProcess(ctx, compiler)
+      }
+    }
+  }
+
+  def postProcess(ctx: PostProcessContext, compiler: MarkdownCompiler): String = {
+    val (runs, inputs) = reset()
+    val code = new CodeBuilder()
+    val wrapped = code
+      .println("object mdocjs {")
+      .foreach(runs)(code.println)
+      .println("}")
+      .toString
+    val input = Input.VirtualFile(ctx.relativePath.toString(), wrapped)
+    val edit = TokenEditDistance.fromInputs(inputs, input)
+    val oldErrors = ctx.reporter.errorCount
+    compiler.compileSources(input, ctx.reporter, edit)
+    val hasErrors = ctx.reporter.errorCount > oldErrors
+    val sjsir = for {
+      x <- target.toList
+      if x.name.endsWith(".sjsir")
+    } yield {
+      val f = new MemVirtualSerializedScalaJSIRFile(x.path)
+      f.content = x.toByteArray
+      f: VirtualScalaJSIRFile
+    }
+    if (sjsir.isEmpty) {
+      if (!hasErrors) {
+        ctx.reporter.error("Scala.js compilation failed")
+      }
+      ""
+    } else {
+      val output = WritableMemVirtualJSFile("output.js")
+      linker.link(virtualIrFiles ++ sjsir, Nil, output, sjsLogger)
+      val outfile = outDirectory.resolve(ctx.relativePath.resolveSibling(_ + ".js"))
+      outfile.write(output.content)
+      val outmdoc = outfile.resolveSibling(_ => "mdoc.js")
+      outmdoc.write(Resources.readPath("/mdoc.js"))
+      val relfile = outfile.toRelativeLinkFrom(ctx.outputFile)
+      val relmdoc = outmdoc.toRelativeLinkFrom(ctx.outputFile)
+      new CodeBuilder()
+        .println(s"""<script type="text/javascript" src="$relfile" defer></script>""")
+        .println(s"""<script type="text/javascript" src="$relmdoc" defer></script>""")
+        .toString
+    }
+  }
+
+  override def process(ctx: PreModifierContext): String = {
+    JsMods.parse(ctx.infoInput, ctx.reporter) match {
+      case Some(mods) =>
+        process(ctx, mods)
+      case None =>
+        ""
+    }
+  }
+
+  def process(ctx: PreModifierContext, mods: JsMods): String = {
+    val separator = "\n---\n"
+    val text = ctx.originalCode.text
+    val separatorIndex = text.indexOf(separator)
+    val (body, input) =
+      if (separatorIndex < 0) {
+        ("", ctx.originalCode)
+      } else {
+        val sliced = Input.Slice(
+          ctx.originalCode,
+          separatorIndex + separator.length,
+          ctx.originalCode.chars.length
+        )
+        (
+          text.substring(0, separatorIndex),
+          sliced
+        )
+      }
+    val run = gensym.fresh("run")
+    inputs += input
+    val id = s"mdoc-js-$run"
+    val mountNodeParam = Term.Name(mountNode)
+    val code: String =
+      if (mods.isShared) {
+        input.text
+      } else {
+        new CodeBuilder()
+          .println(s""" @_root_.scala.scalajs.js.annotation.JSExportTopLevel("$id") """)
+          .println(s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.Element): Unit = {""")
+          .println(input.text)
+          .println("}")
+          .toString
+      }
+    runs += code
+    new CodeBuilder()
+      .printlnIf(!mods.isInvisible, s"```scala\n${input.text}\n```")
+      .printlnIf(!mods.isShared, s"""<div id="$id" data-mdoc-js>$body</div>""")
+      .toString
+  }
+}

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsMods.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsMods.scala
@@ -1,0 +1,39 @@
+package mdoc.modifiers
+
+import mdoc.Reporter
+import mdoc.internal.pos.PositionSyntax._
+import scala.annotation.tailrec
+import scala.meta.inputs.Input
+
+class JsMods private (mods: Set[String]) {
+  def isShared: Boolean = mods("shared")
+  def isInvisible: Boolean = mods("invisible")
+}
+
+object JsMods {
+  val all = Set("shared", "invisible")
+  def parse(info: Input, reporter: Reporter): Option[JsMods] = {
+    val text = info.text
+    @tailrec def loop(from: Int, accum: Set[String]): Option[Set[String]] = {
+      if (from >= text.length) Some(accum)
+      else {
+        val colon = text.indexOf(':', from)
+        val mod = if (colon < 0) {
+          text.substring(from)
+        } else {
+          text.substring(from, colon)
+        }
+        val isValid = all.contains(mod)
+        if (isValid && colon < 0) {
+          loop(text.length + 1, accum + mod)
+        } else if (isValid) {
+          loop(colon + 1, accum + mod)
+        } else {
+          reporter.error(info.toPosition.addStart(from), s"invalid modifier '$mod'")
+          None
+        }
+      }
+    }
+    loop(0, Set.empty).map(new JsMods(_))
+  }
+}

--- a/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
@@ -80,6 +80,9 @@ object DocusaurusPlugin extends AutoPlugin {
     aggregate.in(docusaurusPublishGhpages) := false,
     aggregate.in(docusaurusCreateSite) := false,
     docusaurusProjectName := moduleName.value.stripSuffix("-docs"),
+    MdocPlugin.mdocInternalVariables ++= List(
+      "js-out-prefix" -> "assets"
+    ),
     docusaurusPublishGhpages := {
       m.mdoc.toTask(" ").value
       val tmp = Files.createTempFile("docusaurus", "install_ssh.sh")

--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -41,58 +41,105 @@ object MdocPlugin extends AutoPlugin {
         "Additional command-line arguments to pass on every mdoc invocation. " +
           "For example, add --no-link-hygiene to disable link hygiene."
       )
+    val mdocJS =
+      settingKey[Option[Project]](
+        "Optional Scala.js classpath and compiler options to use for the mdoc:js modifier. " +
+          "To use this setting, set the value to `mdocJS := Some(jsproject)` where `jsproject` must be a Scala.js project."
+      )
     val mdocAutoDependency =
       settingKey[Boolean](
         "If false, do not add mdoc as a library dependency this project. " +
           "Default value is true."
       )
   }
+  val mdocInternalVariables =
+    settingKey[List[(String, String)]](
+      " variables that can be referenced from markdown with @VERSION@."
+    )
   import autoImport._
 
-  override def projectSettings: Seq[Def.Setting[_]] = List(
-    mdocIn := baseDirectory.in(ThisBuild).value / "docs",
-    mdocOut := target.in(Compile).value / "mdoc",
-    mdocVariables := Map.empty,
-    mdocAutoDependency := true,
-    mdocExtraArguments := Nil,
-    mdoc := Def.inputTaskDyn {
-      val parsed = sbt.complete.DefaultParsers.spaceDelimited("<arg>").parsed
-      val args = mdocExtraArguments.value ++ parsed
-      Def.taskDyn {
-        runMain.in(Compile).toTask(s" mdoc.Main ${args.mkString(" ")}")
+  override def projectSettings: Seq[Def.Setting[_]] =
+    List(
+      mdocInternalVariables := Nil,
+      mdocIn := baseDirectory.in(ThisBuild).value / "docs",
+      mdocOut := target.in(Compile).value / "mdoc",
+      mdocVariables := Map.empty,
+      mdocAutoDependency := true,
+      mdocExtraArguments := Nil,
+      mdoc := Def.inputTaskDyn {
+        val parsed = sbt.complete.DefaultParsers.spaceDelimited("<arg>").parsed
+        val args = mdocExtraArguments.value ++ parsed
+        Def.taskDyn {
+          runMain.in(Compile).toTask(s" mdoc.Main ${args.mkString(" ")}")
+        }
+      }.evaluated,
+      libraryDependencies ++= {
+        val isJS = mdocJS.value.isDefined
+        if (mdocAutoDependency.value) {
+          val suffix = if (isJS) "-js" else ""
+          List("org.scalameta" %% s"mdoc$suffix" % BuildInfo.version)
+        } else {
+          List()
+        }
+      },
+      resourceGenerators.in(Compile) += Def.task {
+        val out =
+          managedResourceDirectories.in(Compile).value.head / "mdoc.properties"
+        val props = new java.util.Properties()
+        mdocVariables.value.foreach {
+          case (key, value) =>
+            props.put(key, value)
+        }
+        mdocInternalVariables.value.foreach {
+          case (key, value) =>
+            props.put(key, value)
+        }
+        mdocJSCompileOptions.value.foreach { options =>
+          props.put(
+            s"js-scalacOptions",
+            options.options.mkString(" ")
+          )
+          props.put(
+            s"js-classpath",
+            options.classpath.mkString(java.io.File.pathSeparator)
+          )
+        }
+        props.put("in", mdocIn.value.toString)
+        props.put("out", mdocOut.value.toString)
+        props.put(
+          "scalacOptions",
+          scalacOptions.in(Compile).value.mkString(" ")
+        )
+        val classpath = ListBuffer.empty[File]
+        // Can't use fullClasspath.value because it introduces cyclic dependency between
+        // compilation and resource generation.
+        classpath ++= dependencyClasspath.in(Compile).value.iterator.map(_.data)
+        classpath += classDirectory.in(Compile).value
+        props.put(
+          "classpath",
+          classpath.mkString(java.io.File.pathSeparator)
+        )
+        IO.write(props, "mdoc properties", out)
+        List(out)
       }
-    }.evaluated,
-    libraryDependencies ++= {
-      if (mdocAutoDependency.value) {
-        List("org.scalameta" %% "mdoc" % BuildInfo.version)
-      } else {
-        List()
+    )
+
+  private val mdocJSCompileOptions: Def.Initialize[Task[Option[CompileOptions]]] =
+    Def.taskDyn[Option[CompileOptions]] {
+      mdocJS.value match {
+        case Some(p) =>
+          mdocCompileOptions(p).map(Some(_))
+        case None =>
+          Def.task(None)
       }
-    },
-    resourceGenerators.in(Compile) += Def.task {
-      val out =
-        managedResourceDirectories.in(Compile).value.head / "mdoc.properties"
-      val props = new java.util.Properties()
-      mdocVariables.value.foreach {
-        case (key, value) =>
-          props.put(key, value)
-      }
-      props.put("in", mdocIn.value.toString)
-      props.put("out", mdocOut.value.toString)
-      props.put(
-        "scalacOptions",
-        scalacOptions.in(Compile).value.mkString(" ")
-      )
-      val classpath = ListBuffer.empty[File]
-      classpath ++= dependencyClasspath.in(Compile).value.iterator.map(_.data)
-      classpath += classDirectory.in(Compile).value
-      props.put(
-        "classpath",
-        classpath.mkString(java.io.File.pathSeparator)
-      )
-      IO.write(props, "mdoc properties", out)
-      List(out)
     }
-  )
+  private case class CompileOptions(options: Seq[String], classpath: Seq[File])
+  private def mdocCompileOptions(ref: Project): Def.Initialize[Task[CompileOptions]] =
+    Def.task {
+      CompileOptions(
+        scalacOptions.in(ref, Compile).value,
+        fullClasspath.in(ref, Compile).value.map(_.data)
+      )
+    }
 
 }

--- a/mdoc/src/main/resources/custom.css
+++ b/mdoc/src/main/resources/custom.css
@@ -100,3 +100,7 @@ hr {
     display: none;
   }
 }
+
+div[data-mdoc-js] {
+  background-color: blanchedalmond;
+}

--- a/mdoc/src/main/scala/mdoc/PreModifier.scala
+++ b/mdoc/src/main/scala/mdoc/PreModifier.scala
@@ -1,0 +1,69 @@
+package mdoc
+
+import java.util.ServiceLoader
+import mdoc.internal.cli.Settings
+import metaconfig.ConfDecoder
+import metaconfig.ConfEncoder
+import metaconfig.ConfError
+import metaconfig.generic.Surface
+import scala.meta.inputs.Input
+import scala.meta.io.AbsolutePath
+import scala.collection.JavaConverters._
+import scala.meta.io.RelativePath
+import mdoc.internal.pos.PositionSyntax._
+import scala.meta.inputs.Position
+
+trait PreModifier {
+  val name: String
+  def onLoad(ctx: OnLoadContext): Unit = ()
+  def process(ctx: PreModifierContext): String
+  def postProcess(ctx: PostProcessContext): String = ""
+}
+
+object PreModifier {
+  def default(): List[PreModifier] = default(this.getClass.getClassLoader)
+  def default(classLoader: ClassLoader): List[PreModifier] =
+    ServiceLoader.load(classOf[PreModifier], classLoader).iterator().asScala.toList
+  implicit val surface: Surface[Settings] = new Surface(Nil)
+  implicit val decoder: ConfDecoder[PreModifier] =
+    ConfDecoder.instanceF[PreModifier](_ => ConfError.message("unsupported").notOk)
+  implicit val encoder: ConfEncoder[PreModifier] =
+    ConfEncoder.StringEncoder.contramap(mod => s"<${mod.name}>")
+}
+
+final class OnLoadContext private[mdoc] (
+    val reporter: Reporter,
+    private[mdoc] val settings: Settings
+) {
+  def site: Map[String, String] = settings.site
+}
+
+final class PostProcessContext private[mdoc] (
+    val reporter: Reporter,
+    val relativePath: RelativePath,
+    private[mdoc] val settings: Settings
+) {
+  def inputFile: AbsolutePath = inDirectory.resolve(relativePath)
+  def outputFile: AbsolutePath = outDirectory.resolve(relativePath)
+  def inDirectory: AbsolutePath = settings.in
+  def outDirectory: AbsolutePath = settings.out
+}
+
+final class PreModifierContext private[mdoc] (
+    val info: String,
+    val originalCode: Input,
+    val reporter: Reporter,
+    val relativePath: RelativePath,
+    private[mdoc] val settings: Settings
+) {
+  def infoInput: Input = {
+    val cpos = originalCode.toPosition.toUnslicedPosition
+    val start = cpos.start - info.length - 1
+    val end = cpos.start - 1
+    Input.Slice(cpos.input, start, end)
+  }
+  def inputFile: AbsolutePath = inDirectory.resolve(relativePath)
+  def outputFile: AbsolutePath = outDirectory.resolve(relativePath)
+  def inDirectory: AbsolutePath = settings.in
+  def outDirectory: AbsolutePath = settings.out
+}

--- a/mdoc/src/main/scala/mdoc/internal/cli/MdocProperties.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MdocProperties.scala
@@ -1,5 +1,6 @@
 package mdoc.internal.cli
 
+import java.nio.file.Files
 import java.util.Properties
 import scala.collection.JavaConverters._
 import scala.meta.io.AbsolutePath
@@ -13,6 +14,13 @@ case class MdocProperties(
 )
 
 object MdocProperties {
+  def fromFile(path: AbsolutePath): MdocProperties = {
+    val props = new Properties()
+    val in = Files.newInputStream(path.toNIO)
+    try props.load(in)
+    finally in.close()
+    fromProps(props, path)
+  }
   def fromProps(props: Properties, cwd: AbsolutePath): MdocProperties = {
     def getPath(key: String): Option[AbsolutePath] =
       Option(props.getProperty(key)).map(AbsolutePath(_)(cwd))

--- a/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
@@ -15,7 +15,7 @@ class ConsoleReporter(
 ) extends Reporter {
 
   def formatMessage(pos: Position, severity: String, message: String): String =
-    pos.formatMessage(severity, message)
+    pos.formatMessage("", message)
 
   private val myInfo = blue("info")
   private val myWarning = yellow("warning")

--- a/mdoc/src/main/scala/mdoc/internal/livereload/Resources.scala
+++ b/mdoc/src/main/scala/mdoc/internal/livereload/Resources.scala
@@ -1,0 +1,18 @@
+package mdoc.internal.livereload
+
+import java.nio.charset.StandardCharsets
+import scala.meta.internal.io.InputStreamIO
+
+object Resources {
+  def readPath(path: String): String = {
+    val is = this.getClass.getResourceAsStream(path)
+    if (is == null) {
+      throw new NoSuchElementException(path)
+    }
+    val bytes =
+      try InputStreamIO.readBytes(is)
+      finally is.close()
+    val text = new String(bytes, StandardCharsets.UTF_8)
+    text
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/livereload/UndertowLiveReload.scala
+++ b/mdoc/src/main/scala/mdoc/internal/livereload/UndertowLiveReload.scala
@@ -120,11 +120,7 @@ object UndertowLiveReload {
   }
 
   private def staticResource(path: String): HttpHandler = {
-    val is = this.getClass.getResourceAsStream(path)
-    val bytes =
-      try InputStreamIO.readBytes(is)
-      finally is.close()
-    val text = new String(bytes, StandardCharsets.UTF_8)
+    val text = Resources.readPath(path)
     new HttpHandler {
       override def handleRequest(exchange: HttpServerExchange): Unit = {
         exchange.getResponseHeaders.put(Headers.CONTENT_TYPE, contentType(path))

--- a/mdoc/src/main/scala/mdoc/internal/markdown/BlockInput.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/BlockInput.scala
@@ -7,7 +7,9 @@ import mdoc.internal.cli.Context
 import mdoc.internal.markdown.Modifier.Str
 import mdoc.internal.markdown.Modifier.Default
 import mdoc.internal.markdown.Modifier.Post
+import mdoc.internal.markdown.Modifier.Pre
 
+case class PreBlockInput(block: FencedCodeBlock, input: Input, mod: Pre)
 case class StringBlockInput(block: FencedCodeBlock, input: Input, mod: Str)
 case class ScalaBlockInput(block: FencedCodeBlock, input: Input, mod: Modifier)
 
@@ -36,6 +38,12 @@ class BlockInput(ctx: Context, baseInput: Input) {
                     Post(mod, info)
                 }
               }
+              .orElse {
+                ctx.settings.preModifiers.collectFirst {
+                  case mod if mod.name == name =>
+                    Pre(mod, info)
+                }
+              }
           }
           .orElse {
             invalid(block, s"Invalid mode '$mode'")
@@ -53,7 +61,7 @@ class BlockInput(ctx: Context, baseInput: Input) {
     ctx.reporter.error(pos, message)
   }
   private def invalidCombination(block: FencedCodeBlock, mod1: String, mod2: String): Boolean = {
-    invalid(block, s"invalid combination of modifiers '$mod1' and '$mod2' are ")
+    invalid(block, s"invalid combination of modifiers '$mod1' and '$mod2'")
     false
   }
 

--- a/mdoc/src/main/scala/mdoc/internal/markdown/CodeBuilder.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/CodeBuilder.scala
@@ -1,0 +1,34 @@
+package mdoc.internal.markdown
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+
+class CodeBuilder() {
+  private val out = new ByteArrayOutputStream()
+  private val ps = new PrintStream(out)
+  def printIf(cond: Boolean, s: String): CodeBuilder = {
+    if (cond) print(s)
+    else this
+  }
+  def print(s: String): CodeBuilder = {
+    ps.print(s)
+    this
+  }
+  def printlnIf(cond: Boolean, s: String): CodeBuilder = {
+    if (cond) println(s)
+    else this
+  }
+  def foreach[T](xs: Iterable[T])(fn: T => Unit): CodeBuilder = {
+    xs.foreach(fn)
+    this
+  }
+  def println(s: String): CodeBuilder = {
+    ps.println(s)
+    this
+  }
+
+  override def toString: String = {
+    out.toString(StandardCharsets.UTF_8.name)
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/EvaluatedDocument.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/EvaluatedDocument.scala
@@ -14,7 +14,7 @@ object EvaluatedDocument {
   def apply(document: Document, trees: List[SectionInput]): EvaluatedDocument = {
     val instrumented =
       Input.VirtualFile(document.instrumented.filename, document.instrumented.text)
-    val edit = TokenEditDistance.toTokenEdit(trees.map(_.source), instrumented)
+    val edit = TokenEditDistance.fromTrees(trees.map(_.source), instrumented)
     EvaluatedDocument(
       instrumented,
       edit,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Gensym.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Gensym.scala
@@ -2,6 +2,9 @@ package mdoc.internal.markdown
 
 class Gensym() {
   private var counter = 0
+  def reset(): Unit = {
+    counter = 0
+  }
   def fresh(prefix: String, suffix: String = ""): String = {
     val name = s"$prefix$counter$suffix"
     counter += 1

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Modifier.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Modifier.scala
@@ -19,6 +19,7 @@ sealed abstract class Modifier(mods: Set[Mod]) {
   def isFail: Boolean = mods(Fail)
   def isPassthrough: Boolean = mods(Passthrough)
   def isString: Boolean = this.isInstanceOf[Modifier.Str]
+  def isPre: Boolean = this.isInstanceOf[Modifier.Pre]
   def isPost: Boolean = this.isInstanceOf[Modifier.Post]
   def isCrash: Boolean = mods(Crash)
   def isSilent: Boolean = mods(Silent)
@@ -55,11 +56,8 @@ object Modifier {
   }
 
   case class Builtin(mods: Set[Mod]) extends Modifier(mods)
-
-  /** Render this code fence according to this string modifier */
   case class Str(mod: StringModifier, info: String) extends Modifier(Set.empty)
-
-  /** Render this code fence according to this post modifier */
   case class Post(mod: mdoc.PostModifier, info: String) extends Modifier(Set.empty)
+  case class Pre(mod: mdoc.PreModifier, info: String) extends Modifier(Set.empty)
 
 }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/ModifierException.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/ModifierException.scala
@@ -1,0 +1,7 @@
+package mdoc.internal.markdown
+
+import scala.util.control.NoStackTrace
+
+final class ModifierException(mod: String, cause: Throwable)
+    extends Exception(s"mdoc:$mod exception", cause)
+    with NoStackTrace

--- a/mdoc/src/main/scala/mdoc/internal/markdown/StringModifierException.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/StringModifierException.scala
@@ -1,8 +1,0 @@
-package mdoc.internal.markdown
-
-import scala.util.control.NoStackTrace
-import mdoc.StringModifier
-
-final class StringModifierException(mod: StringModifier, cause: Throwable)
-    extends Exception(mod.name, cause)
-    with NoStackTrace

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -1,5 +1,7 @@
 package mdoc.internal.pos
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Paths
 import scala.meta.Input
 import scala.meta.Position
@@ -25,6 +27,9 @@ object PositionSyntax {
     def toFilename(settings: Settings): String =
       if (settings.reportRelativePaths) Paths.get(input.filename).getFileName.toString
       else filename
+    def toPosition: Position.Range = {
+      Position.Range(input, 0, input.chars.length)
+    }
     def toOffset(line: Int, column: Int): Position = {
       Position.Range(input, line, column, line, column)
     }
@@ -68,6 +73,12 @@ object PositionSyntax {
     }
   }
   implicit class XtensionPositionMdoc(pos: Position) {
+    def addStart(offset: Int): Position = pos match {
+      case Position.Range(i, start, end) =>
+        Position.Range(i, start + offset, end)
+      case _ =>
+        pos
+    }
     def toUnslicedPosition: Position = pos.input match {
       case Input.Slice(underlying, a, _) =>
         Position.Range(underlying, a + pos.start, a + pos.end).toUnslicedPosition
@@ -91,7 +102,8 @@ object PositionSyntax {
   ): String =
     pos match {
       case Position.None =>
-        s"$severity: $message"
+        if (severity.isEmpty) message
+        else s"$severity: $message"
       case _ =>
         new java.lang.StringBuilder()
           .append(if (includePath) pos.lineInput else "")
@@ -159,5 +171,18 @@ object PositionSyntax {
       else if (e.getCause != null) e.getCause.message
       else "null"
     }
+  }
+  implicit class XtensionAbsolutePathLink(path: AbsolutePath) {
+    def write(text: String): Unit = {
+      Files.createDirectories(path.toNIO.getParent)
+      Files.write(
+        path.toNIO,
+        text.getBytes(StandardCharsets.UTF_8)
+      )
+    }
+    def toRelativeLinkFrom(other: AbsolutePath): String = {
+      path.toRelative(other.parent).toURI(false).toString
+    }
+    def parent: AbsolutePath = AbsolutePath(path.toNIO.getParent)
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
@@ -147,12 +147,12 @@ object TokenEditDistance {
         original.pos.text == revised.pos.text
   }
 
-  def toTokenEdit(original: Seq[Tree], instrumented: Input): TokenEditDistance = {
+  def fromTokens(original: Seq[Tokens], instrumented: Input): TokenEditDistance = {
     val instrumentedTokens = instrumented.tokenize.get
     val originalTokens: Array[Token] = {
       val buf = Array.newBuilder[Token]
-      original.foreach { tree =>
-        tree.tokens.foreach { token =>
+      original.foreach { tokens =>
+        tokens.foreach { token =>
           buf += token
         }
       }
@@ -161,4 +161,11 @@ object TokenEditDistance {
     TokenEditDistance(originalTokens, instrumentedTokens)
   }
 
+  def fromTrees(original: Seq[Tree], instrumented: Input): TokenEditDistance = {
+    fromTokens(original.map(_.tokens), instrumented)
+  }
+
+  def fromInputs(original: Seq[Input], instrumented: Input): TokenEditDistance = {
+    fromTokens(original.map(_.tokenize.get), instrumented)
+  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,7 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % coursier.util.Properties.versi
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 libraryDependencies += "org.jsoup" % "jsoup" % "1.11.3"
 unmanagedSourceDirectories.in(Compile) +=
   baseDirectory.in(ThisBuild).value.getParentFile /

--- a/tests/jsapp/src/main/scala/jsapp/ExampleJS.scala
+++ b/tests/jsapp/src/main/scala/jsapp/ExampleJS.scala
@@ -1,0 +1,5 @@
+package jsapp
+
+object ExampleJS {
+  val greeting = "Hello!"
+}

--- a/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
@@ -20,7 +20,7 @@ class ScalacOptionsSuite extends BaseCliSuite {
     onStdout = { out =>
       val expected =
         """
-          |warning: index.md:3:1: warning: Unused import
+          |warning: index.md:3:1: Unused import
           |import scala.concurrent.Future
           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^""".stripMargin
       assert(out.contains(expected))

--- a/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
@@ -1,12 +1,5 @@
 package tests.markdown
 
-import java.util.concurrent.Executors
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-
 class AsyncSuite extends BaseMarkdownSuite {
   check(
     "await",
@@ -32,7 +25,7 @@ class AsyncSuite extends BaseMarkdownSuite {
       |Await.result(Future(Thread.sleep(1000)), Duration("10ms"))
       |```
     """.stripMargin,
-    """|error: timeout.md:4:1: error: Futures timed out after [10 milliseconds]
+    """|error: timeout.md:4:1: Futures timed out after [10 milliseconds]
        |Await.result(Future(Thread.sleep(1000)), Duration("10ms"))
        |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |java.lang.ExceptionInInitializerError

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -6,11 +6,13 @@ import java.io.PrintStream
 import java.nio.file.Files
 import mdoc.Reporter
 import mdoc.internal.cli.Context
+import mdoc.internal.cli.MdocProperties
 import mdoc.internal.cli.Settings
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.Markdown
 import mdoc.internal.markdown.MarkdownCompiler
 import scala.meta.inputs.Input
+import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.meta.testkit.DiffAssertions
 import tests.markdown.StringSyntax._
@@ -25,12 +27,18 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
           "version" -> "1.0"
         )
       )
+      .withProperties(MdocProperties.default(PathIO.workingDirectory))
   private val myStdout = new ByteArrayOutputStream()
-  private def newReporter(): ConsoleReporter = new ConsoleReporter(new PrintStream(myStdout))
+  private def newReporter(): ConsoleReporter = {
+    new ConsoleReporter(new PrintStream(myStdout))
+  }
   protected def scalacOptions: String = ""
   private val compiler = MarkdownCompiler.fromClasspath("", scalacOptions)
-  private def newContext(settings: Settings, reporter: Reporter) =
+  private def newContext(settings: Settings, reporter: ConsoleReporter) = {
+    settings.validate(reporter)
+    if (reporter.hasErrors) fail()
     Context(settings, reporter, compiler)
+  }
 
   def getMarkdownSettings(context: Context): MutableDataSet = {
     myStdout.reset()
@@ -54,11 +62,11 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
     }
   }
 
-  def check(
+  def checkCompiles(
       name: String,
       original: String,
-      expected: String,
-      settings: Settings = baseSettings
+      settings: Settings = baseSettings,
+      onOutput: String => Unit = _ => ()
   ): Unit = {
     test(name) {
       val reporter = newReporter()
@@ -71,8 +79,19 @@ abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAsserti
       val stdout = fansi.Str(colorOut).plainText
       assert(!reporter.hasErrors, stdout)
       assert(!reporter.hasWarnings, stdout)
-      assertNoDiffOrPrintExpected(obtained, expected)
+      onOutput(obtained)
     }
+  }
+
+  def check(
+      name: String,
+      original: String,
+      expected: String,
+      settings: Settings = baseSettings
+  ): Unit = {
+    checkCompiles(name, original, settings, obtained => {
+      assertNoDiffOrPrintExpected(obtained, expected)
+    })
   }
 
 }

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -28,7 +28,7 @@ class CrashSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: definition.md:3:1: error: Expected runtime exception but program completed successfully
+      |error: definition.md:3:1: Expected runtime exception but program completed successfully
       |case class User(name: String)
       |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     """.stripMargin
@@ -42,7 +42,7 @@ class CrashSuite extends BaseMarkdownSuite {
       |```
   """.stripMargin,
     """
-      |error: false-positive.md:3:1: error: Expected runtime exception but program completed successfully
+      |error: false-positive.md:3:1: Expected runtime exception but program completed successfully
       |"ab".length
       |^^^^^^^^^^^
     """.stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
@@ -16,7 +16,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |x + y + z
       |```
     """.stripMargin,
-    """|error: crash.md:10:1: error: an implementation is missing
+    """|error: crash.md:10:1: an implementation is missing
        |x + y + z
        |^^^^^^^^^
        |scala.NotImplementedError: an implementation is missing
@@ -37,7 +37,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: invalid-mod.md:2:15: error: Invalid mode 'foobaz'
+      |error: invalid-mod.md:2:15: Invalid mode 'foobaz'
       |```scala mdoc:foobaz
       |              ^^^^^^
     """.stripMargin
@@ -55,7 +55,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: silent.md:7:1: error: Expected compile error but statement typechecked successfully
+      |error: silent.md:7:1: Expected compile error but statement typechecked successfully
       |List(1)
       |^^^^^^^
     """.stripMargin
@@ -68,7 +68,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: parse-error.md:3:8: error: illegal start of simple expression
+      |error: parse-error.md:3:8: illegal start of simple expression
       |val x =
       |       ^
     """.stripMargin
@@ -80,7 +80,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |List(1).len
       |```
     """.stripMargin,
-    """|error: not-member.md:3:1: error: value len is not a member of List[Int]
+    """|error: not-member.md:3:1: value len is not a member of List[Int]
        |List(1).len
        |^^^^^^^^^^^
     """.stripMargin
@@ -94,7 +94,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |val x = 2
       |```
     """.stripMargin,
-    """|error: already-defined.md:4:5: error: x is already defined as value x
+    """|error: already-defined.md:4:5: x is already defined as value x
        |val x = 2
        |    ^
     """.stripMargin
@@ -107,7 +107,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |List[Int]("".length.toString)
       |```
     """.stripMargin,
-    """|error: yrangepos.md:3:11: error: type mismatch;
+    """|error: yrangepos.md:3:11: type mismatch;
        | found   : String
        | required: Int
        |List[Int]("".length.toString)
@@ -122,7 +122,7 @@ class ErrorSuite extends BaseMarkdownSuite {
       |List[Int]("".length.toString)
       |```
     """.stripMargin,
-    """|error: multimods-typo.md:2:15: error: Invalid mode 'reset:silen'
+    """|error: multimods-typo.md:2:15: Invalid mode 'reset:silen'
        |```scala mdoc:reset:silen
        |              ^^^^^^^^^^^
     """.stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -53,7 +53,7 @@ class FailSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: fail-error.md:3:1: error: not found: value foobar
+      |error: fail-error.md:3:1: not found: value foobar
       |foobar
       |^^^^^^
       |""".stripMargin
@@ -67,7 +67,7 @@ class FailSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: fail-success.md:3:1: error: Expected compile error but statement typechecked successfully
+      |error: fail-success.md:3:1: Expected compile error but statement typechecked successfully
       |1.to(2)
       |^^^^^^^
       |""".stripMargin
@@ -86,7 +86,7 @@ class FailSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: mixed-error.md:3:9: error: not found: value foobar
+      |error: mixed-error.md:3:9: not found: value foobar
       |val x = foobar
       |        ^^^^^^
       |""".stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/JsModsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/JsModsSuite.scala
@@ -1,0 +1,44 @@
+package tests.markdown
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import mdoc.internal.io.ConsoleReporter
+import mdoc.modifiers.JsMods
+import scala.meta.inputs.Input
+
+class JsModsSuite extends BaseMarkdownSuite {
+  def parsed(info: String, fn: (String, Option[JsMods]) => Unit): Unit = {
+    test(if (info.isEmpty) "<empty>" else info) {
+      val input = Input.String(info)
+      val out = new ByteArrayOutputStream()
+      val reporter = new ConsoleReporter(new PrintStream(out))
+      val mods = JsMods.parse(input, reporter)
+      val stdout = fansi.Str(out.toString(StandardCharsets.UTF_8.name))
+      fn(stdout.plainText, mods)
+    }
+  }
+  def checkError(str: String, expected: String): Unit = {
+    parsed(str, (err, res) => {
+      assertNoDiffOrPrintExpected(err, expected)
+      assert(res.isEmpty)
+    })
+  }
+  def checkOK(str: String): Unit = {
+    parsed(str, (err, res) => {
+      assertNoDiffOrPrintExpected(err, "")
+      assert(res.isDefined)
+    })
+  }
+  checkOK("")
+  checkOK("shared")
+  checkOK("invisible")
+  checkOK("shared:invisible")
+  checkError(
+    "shared:invisible:foo",
+    """|error: <input>:1:18: invalid modifier 'foo'
+       |shared:invisible:foo
+       |                 ^^^
+    """.stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/markdown/JsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/JsSuite.scala
@@ -1,0 +1,244 @@
+package tests.markdown
+
+import java.nio.file.Paths
+import mdoc.internal.cli.Settings
+import scala.meta.io.Classpath
+import tests.markdown.StringSyntax._
+
+class JsSuite extends BaseMarkdownSuite {
+  // NOTE(olafur) Optimization. Cache settings to reuse the Scala.js compiler instance.
+  // By default, we create new modifiers for each unit test, which is usually fast.
+  override lazy val baseSettings: Settings = super.baseSettings.copy(
+    site = super.baseSettings.site ++ Map(
+      "js-opt" -> "fast"
+    )
+  )
+
+  def suffix(name: String): String =
+    s"""|<script type="text/javascript" src="$name.md.js" defer></script>
+        |
+        |<script type="text/javascript" src="mdoc.js" defer></script>
+        |""".stripMargin
+
+  check(
+    "basic",
+    """
+      |```scala mdoc:js
+      |println("hello world!")
+      |```
+    """.stripMargin,
+    """|```scala
+       |println("hello world!")
+       |```
+       |
+       |<div id="mdoc-js-run0" data-mdoc-js></div>
+       |
+       |<script type="text/javascript" src="basic.md.js" defer></script>
+       |
+       |<script type="text/javascript" src="mdoc.js" defer></script>
+    """.stripMargin
+  )
+
+  checkError(
+    "error",
+    """
+      |```scala mdoc:js
+      |val x: Int = ""
+      |```
+    """.stripMargin,
+    """
+      |error: error.md:3:14: type mismatch;
+      | found   : String("")
+      | required: Int
+      |val x: Int = ""
+      |             ^^
+    """.stripMargin
+  )
+
+  check(
+    "multi",
+    """
+      |```scala mdoc:js
+      |println("hello 1!")
+      |```
+      |
+      |```scala mdoc:js
+      |println("hello 2!")
+      |```
+    """.stripMargin,
+    """|```scala
+       |println("hello 1!")
+       |```
+       |
+       |<div id="mdoc-js-run0" data-mdoc-js></div>
+       |
+       |```scala
+       |println("hello 2!")
+       |```
+       |
+       |<div id="mdoc-js-run1" data-mdoc-js></div>
+       |
+       |<script type="text/javascript" src="multi.md.js" defer></script>
+       |
+       |<script type="text/javascript" src="mdoc.js" defer></script>
+       |""".stripMargin
+  )
+
+  checkError(
+    "edit",
+    """
+      |```scala mdoc:js
+      |val x: Int = ""
+      |```
+      |
+      |```scala mdoc:js
+      |val y: String = 42
+      |```
+    """.stripMargin,
+    """|error: edit.md:3:14: type mismatch;
+       | found   : String("")
+       | required: Int
+       |val x: Int = ""
+       |             ^^
+       |error: edit.md:7:17: type mismatch;
+       | found   : Int(42)
+       | required: String
+       |val y: String = 42
+       |                ^^
+    """.stripMargin
+  )
+
+  checkError(
+    "isolated",
+    """
+      |```scala mdoc:js
+      |val x = 1
+      |```
+      |
+      |```scala mdoc:js
+      |println(x)
+      |```
+    """.stripMargin,
+    """|error: isolated.md:7:9: not found: value x
+       |println(x)
+       |        ^
+    """.stripMargin
+  )
+
+  checkCompiles(
+    "mountNode",
+    """
+      |```scala mdoc:js
+      |node.innerHTML = "<h3>Hello world!</h3>"
+      |```
+    """.stripMargin
+  )
+
+  check(
+    "shared",
+    """
+      |```scala mdoc:js:shared
+      |val x = 1
+      |```
+      |
+      |```scala mdoc:js
+      |println(x)
+      |```
+    """.stripMargin,
+    """|```scala
+       |val x = 1
+       |```
+       |
+       |```scala
+       |println(x)
+       |```
+       |
+       |<div id="mdoc-js-run1" data-mdoc-js></div>
+       |
+       |<script type="text/javascript" src="shared.md.js" defer></script>
+       |
+       |<script type="text/javascript" src="mdoc.js" defer></script>
+    """.stripMargin
+  )
+
+  // It's easy to mess up stripMargin multiline strings when generating code with strings.
+  check(
+    "stripMargin",
+    """
+      |```scala mdoc:js
+      |val x = '''
+      |  |a
+      |  | b
+      |  |  c
+      | '''.stripMargin
+      |```
+    """.stripMargin.triplequoted,
+    s"""|```scala
+        |val x = '''
+        |  |a
+        |  | b
+        |  |  c
+        | '''.stripMargin
+        |```
+        |
+        |<div id="mdoc-js-run0" data-mdoc-js></div>
+        |
+        |${suffix("stripMargin")}
+        |""".stripMargin.triplequoted
+  )
+
+  check(
+    "invisible",
+    """
+      |```scala mdoc:js:invisible
+      |println("Hello!")
+      |```
+    """.stripMargin,
+    s"""|
+        |<div id="mdoc-js-run0" data-mdoc-js></div>
+        |
+        |${suffix("invisible")}
+        |""".stripMargin
+  )
+
+  checkCompiles(
+    "deps",
+    """
+      |```scala mdoc:js
+      |println(jsapp.ExampleJS.greeting)
+      |```
+    """.stripMargin
+  )
+
+  checkError(
+    "no-dom",
+    """
+      |```scala mdoc:js
+      |println(jsapp.ExampleJS.greeting)
+      |```
+    """.stripMargin,
+    """|error: <mdoc>:3 object scalajs is not a member of package org
+       |def run0(node: _root_.org.scalajs.dom.raw.Element): Unit = {
+       |                          ^
+    """.stripMargin,
+    settings = {
+      val base = super.baseSettings
+      val noScalajsDom = Classpath(base.site("js-classpath")).entries
+        .filterNot(_.toNIO.getFileName.toString.contains("scalajs-dom"))
+      base.copy(site = base.site.updated("js-classpath", Classpath(noScalajsDom).syntax))
+    }
+  )
+
+  checkError(
+    "mods-error",
+    """|
+       |```scala mdoc:js:shared:not
+       |println(1)
+       |```
+    """.stripMargin,
+    """|error: mods-error.md:2:25: invalid modifier 'not'
+       |```scala mdoc:js:shared:not
+       |                        ^^^
+    """.stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
@@ -55,10 +55,10 @@ class LinkHygieneSuite extends FunSuite with DiffAssertions {
       |* [name](a.md#name)
       |
     """.stripMargin,
-    """|warning: a.md:3:7: warning: Unknown link 'a.md#does-not-exist'.
+    """|warning: a.md:3:7: Unknown link 'a.md#does-not-exist'.
        |Error [link](#does-not-exist) failed.
        |      ^^^^^^^^^^^^^^^^^^^^^^^
-       |warning: a.md:4:6: warning: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
+       |warning: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
        |Typo [section](#sectionn) failed.
        |     ^^^^^^^^^^^^^^^^^^^^
     """.stripMargin
@@ -107,7 +107,7 @@ class LinkHygieneSuite extends FunSuite with DiffAssertions {
       |/a.md
       |[absolute](/absolute.md)
     """.stripMargin,
-    """|warning: a.md:1:1: warning: Unknown link '/absolute.md'. To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md.
+    """|warning: a.md:1:1: Unknown link '/absolute.md'. To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md.
        |[absolute](/absolute.md)
        |^^^^^^^^^^^^^^^^^^^^^^^^
     """.stripMargin
@@ -122,7 +122,7 @@ class LinkHygieneSuite extends FunSuite with DiffAssertions {
       |/b.md
       |# Header 2
     """.stripMargin,
-    """|warning: a.md:2:1: warning: Unknown link 'b.md#header', did you mean 'b.md#header-2'?
+    """|warning: a.md:2:1: Unknown link 'b.md#header', did you mean 'b.md#header-2'?
        |isValidHeading:
        |  92  b.md#header-2
        |  83  a.md#header-1

--- a/tests/unit/src/test/scala/tests/markdown/MultiModsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MultiModsSuite.scala
@@ -83,7 +83,7 @@ class MultiModsSuite extends BaseMarkdownSuite {
       |val x = 2
       |```
     """.stripMargin,
-    """|error: silent:invisible.md:2:15: error: invalid combination of modifiers 'silent' and 'invisible' are
+    """|error: silent:invisible.md:2:15: invalid combination of modifiers 'silent' and 'invisible'
        |```scala mdoc:reset:silent:invisible
        |              ^^^^^^^^^^^^^^^^^^^^^^
     """.stripMargin
@@ -96,7 +96,7 @@ class MultiModsSuite extends BaseMarkdownSuite {
       |val x = 2
       |```
     """.stripMargin,
-    """|error: fail:crash.md:2:15: error: invalid combination of modifiers 'crash' and 'fail' are
+    """|error: fail:crash.md:2:15: invalid combination of modifiers 'crash' and 'fail'
        |```scala mdoc:reset:fail:crash
        |              ^^^^^^^^^^^^^^^^
     """.stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/SilentSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/SilentSuite.scala
@@ -30,7 +30,7 @@ class SilentSuite extends BaseMarkdownSuite {
       |val x: String = 4
       |```
     """.stripMargin,
-    """|error: error.md:3:17: error: type mismatch;
+    """|error: error.md:3:17: type mismatch;
        | found   : Int(4)
        | required: String
        |val x: String = 4

--- a/tests/unit/src/test/scala/tests/markdown/StringModifierSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/StringModifierSuite.scala
@@ -53,7 +53,7 @@ class StringModifierSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: reporter.md:3:1: error: This is a message
+      |error: reporter.md:3:1: This is a message
       |hello
       |^^^^^
     """.stripMargin
@@ -67,10 +67,10 @@ class StringModifierSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: exception.md:3:1: error: exception
+      |error: exception.md:3:1: mdoc:exception exception
       |hello
       |^^^^^
-      |mdoc.internal.markdown.StringModifierException: exception
+      |mdoc.internal.markdown.ModifierException: mdoc:exception exception
       |Caused by: java.lang.IllegalArgumentException: boom
       |	at tests.markdown.StringModifierSuite$$anon$3.process(StringModifierSuite.scala:30)
     """.stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/VariableRegexSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariableRegexSuite.scala
@@ -13,7 +13,7 @@ class VariableRegexSuite extends BaseMarkdownSuite {
       |```scala
       |libraryDeps += "1.0"
       |```
-    """.stripMargin,
+    """.stripMargin
   )
 
   checkError(
@@ -24,10 +24,10 @@ class VariableRegexSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """
-      |error: missing-key.md:3:17: error: key not found: unknown
+      |error: missing-key.md:3:17: key not found: unknown
       |libraryDeps += "@unknown@"
       |                ^^^^^^^^^
-    """.stripMargin,
+    """.stripMargin
   )
 
   check(
@@ -45,7 +45,7 @@ class VariableRegexSuite extends BaseMarkdownSuite {
       |x.length // should match "1.0".length
       |// res0: Int = 3
       |```
-    """.stripMargin,
+    """.stripMargin
   )
 
   check(
@@ -55,7 +55,7 @@ class VariableRegexSuite extends BaseMarkdownSuite {
     """.stripMargin,
     """
       |This to @olafurpg
-    """.stripMargin,
+    """.stripMargin
   )
 
   check(
@@ -65,7 +65,7 @@ class VariableRegexSuite extends BaseMarkdownSuite {
     """.stripMargin,
     """
       |This to @version@
-    """.stripMargin,
+    """.stripMargin
   )
 
 }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -14,6 +14,9 @@
       "installation": {
         "title": "Installation"
       },
+      "js": {
+        "title": "Scala.js"
+      },
       "modifiers": {
         "title": "Modifiers"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,5 @@
 {
   "docs": {
-    "Overview": ["installation", "modifiers", "why", "tut", "docusaurus"]
+    "Overview": ["installation", "modifiers", "why", "tut", "docusaurus", "js"]
   }
 }

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,0 +1,3 @@
+div[data-mdoc-js] {
+  background-color: blanchedalmond;
+}


### PR DESCRIPTION
Fixes #125.

This commit adds a new modifier that makes it possible to write
interactive docs with Scala.js.

The following document gets compiled to JavaScript and is evaluated at
HTML load time instead of markdown generation time.
````md
```scala mdoc:js
println("Hello world!")
```
````

The modifier is published as a separate artifact `mdoc-js` because it
brings in a new dependency on the Scala.js compiler.

To implement `mdoc:js`, we add a new `mdoc.PreModifier` which is a more
powerful version of `mdoc.StringModifier`. String modifiers will be
deprecated later. I haven't written docs about pre-modifiers yet, I'd
like to do that separately once `mdoc:js` has proven itself robust
enough.