### PR TITLE
Prohibit --out from being a subdirectory of --in.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - env: TEST="scalafmt"
       script: ./bin/scalafmt --test
     - env: TEST="sbt test"
-      script: sbt test
+      script: sbt test plugin/scripted
     - stage: release
       script: sbt ci-release docs/docusaurusPublishGhpages
 

--- a/build.sbt
+++ b/build.sbt
@@ -133,15 +133,26 @@ lazy val plugin = project
       "org.scalameta" %% "testkit" % "4.0.0-M11" % Test
     ),
     resourceGenerators.in(Compile) += Def.task {
-
       val out =
         managedResourceDirectories.in(Compile).value.head / "sbt-mdoc.properties"
       val props = new java.util.Properties()
       props.put("version", version.value)
       IO.write(props, "sbt-mdoc properties", out)
       List(out)
-    }
+    },
+    publishLocal := publishLocal
+      .dependsOn(
+        publishLocal in runtime,
+        publishLocal in mdoc
+      )
+      .value,
+    scriptedBufferLog := false,
+    scriptedLaunchOpts ++= Seq(
+      "-Xmx2048M",
+      s"-Dplugin.version=${version.value}"
+    )
   )
+  .enablePlugins(ScriptedPlugin)
 
 lazy val js = project
   .in(file("mdoc-js"))

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "@VERSION@" )
 lazy val myproject = project  // your existing library
   .settings(...)
 lazy val docs = project       // new documentation project
-  .in(file("myproject-docs")) // important: must not be docs/
+  .in(file("myproject-docs")) // important: it must not be docs/
   .dependsOn(myproject)
   .enablePlugins(MdocPlugin)
 ```

--- a/mdoc-sbt/src/main/scala/mdoc/MdocException.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocException.scala
@@ -1,0 +1,7 @@
+package mdoc
+
+import sbt.internal.util.FeedbackProvidedException
+
+case class MdocException(message: String)
+    extends Exception(message: String)
+    with FeedbackProvidedException

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/.scalafix.conf
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/.scalafix.conf
@@ -1,8 +1,0 @@
-rules = [
-  RemoveUnused
-  ExplicitResultTypes
-  DisableSyntax
-  "class:fix.Examplescalafixrule_v1" // loaded via scalafixDependencies
-]
-
-DisableSyntax.noSemicolons = true

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/.scalafix.conf
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/.scalafix.conf
@@ -1,0 +1,8 @@
+rules = [
+  RemoveUnused
+  ExplicitResultTypes
+  DisableSyntax
+  "class:fix.Examplescalafixrule_v1" // loaded via scalafixDependencies
+]
+
+DisableSyntax.noSemicolons = true

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,0 +1,13 @@
+scalaVersion := "2.12.8"
+
+enablePlugins(MdocPlugin)
+
+TaskKey[Unit]("check") := {
+  val obtained = IO.read(mdocOut.value / "readme.md")
+  assert(obtained.trim == """
+```scala
+println(example.Example.greeting)
+// Hello world!
+```
+""".trim)
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/docs/readme.md
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/docs/readme.md
@@ -1,0 +1,3 @@
+```scala mdoc
+println(example.Example.greeting)
+```

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))
+addSbtCoursier

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/src/main/scala/example/Example.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/src/main/scala/example/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+object Example {
+  def greeting = "Hello world!"
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
@@ -1,0 +1,2 @@
+> mdoc
+> check

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
@@ -1,2 +1,4 @@
 > mdoc
 > check
+> set mdocIn := baseDirectory.in(ThisBuild).value
+-> mdoc

--- a/mdoc/src/main/scala/mdoc/internal/cli/Feedback.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Feedback.scala
@@ -1,0 +1,12 @@
+package mdoc.internal.cli
+
+import java.nio.file.Path
+
+object Feedback {
+  def outSubdirectoryOfIn(in: Path, out: Path): String = {
+    s"--out cannot be a subdirectory of --in because otherwise mdoc would need to process its own generated docs. " +
+      "To fix this problem, change --out so that it points to an independent directory from --in.\n" +
+      s"  --in=$in\n" +
+      s"  --out=$out"
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -170,12 +170,16 @@ case class Settings(
   }
   def validate(logger: Reporter): Configured[Context] = {
     if (Files.exists(in.toNIO)) {
-      val compiler = MarkdownCompiler.fromClasspath(classpath, scalacOptions)
-      onLoad(logger)
-      if (logger.hasErrors) {
-        Configured.error("Failed to load modifiers")
+      if (out.toNIO.startsWith(in.toNIO)) {
+        Configured.error(Feedback.outSubdirectoryOfIn(in.toNIO, out.toNIO))
       } else {
-        Configured.ok(Context(this, logger, compiler))
+        val compiler = MarkdownCompiler.fromClasspath(classpath, scalacOptions)
+        onLoad(logger)
+        if (logger.hasErrors) {
+          Configured.error("Failed to load modifiers")
+        } else {
+          Configured.ok(Context(this, logger, compiler))
+        }
       }
     } else {
       ConfError.fileDoesNotExist(in.toNIO).notOk

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,10 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
-libraryDependencies += "org.jsoup" % "jsoup" % "1.11.3"
+libraryDependencies ++= List(
+  "org.jsoup" % "jsoup" % "1.11.3",
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+)
 unmanagedSourceDirectories.in(Compile) +=
   baseDirectory.in(ThisBuild).value.getParentFile /
     "mdoc-sbt" / "src" / "main" / "scala"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version)
+addSbtCoursier
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")

--- a/tests/demo/project/plugins.sbt
+++ b/tests/demo/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "0.8.0-SNAPSHOT")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.2.1-SNAPSHOT")

--- a/tests/unit/src/test/scala/tests/cli/CliArgsSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/CliArgsSuite.scala
@@ -1,6 +1,7 @@
 package tests.cli
 
 import java.nio.file.Files
+import mdoc.internal.cli.Feedback
 import org.scalatest.FunSuite
 import scala.meta.internal.io.PathIO
 import scala.meta.testkit.DiffAssertions
@@ -9,8 +10,6 @@ import mdoc.internal.io.ConsoleReporter
 
 class CliArgsSuite extends FunSuite with DiffAssertions {
   private val reporter = ConsoleReporter.default
-  private val tmp = Files.createTempDirectory("mdoc")
-  Files.delete(tmp)
   private val base = Settings.default(PathIO.workingDirectory)
 
   def checkOk(args: List[String], isExpected: Settings => Boolean): Unit = {
@@ -31,6 +30,8 @@ class CliArgsSuite extends FunSuite with DiffAssertions {
     }
   }
 
+  private val tmp = Files.createTempDirectory("mdoc")
+  Files.delete(tmp)
   checkError(
     "--in" :: tmp.toString :: Nil,
     s"File $tmp does not exist."
@@ -39,6 +40,13 @@ class CliArgsSuite extends FunSuite with DiffAssertions {
   checkOk(
     "--site.VERSION" :: "1.0" :: Nil,
     _.site == Map("VERSION" -> "1.0")
+  )
+
+  private val in2 = Files.createTempDirectory("mdoc")
+  private val out2 = in2.resolve("out")
+  checkError(
+    "--in" :: in2.toString :: "--out" :: out2.toString :: Nil,
+    Feedback.outSubdirectoryOfIn(in2, out2)
   )
 
 }


### PR DESCRIPTION
Although it's maybe possible to avoid problems with --exclude, it's
better to outright fail when this happens because it's an invitation
to let mdoc start processing its own generated output causing
exponentially growing input sources.