### PR TITLE
Build sbt-mdoc to sbt 1.0.0 instead of 1.2.8.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val plugin = project
   .in(file("mdoc-sbt"))
   .settings(
     sbtPlugin := true,
+    sbtVersion in pluginCrossBuild := "1.0.0",
     moduleName := "sbt-mdoc",
     libraryDependencies ++= List(
       "org.jsoup" % "jsoup" % "1.11.3",
@@ -143,7 +144,8 @@ lazy val plugin = project
     publishLocal := publishLocal
       .dependsOn(
         publishLocal in runtime,
-        publishLocal in mdoc
+        publishLocal in mdoc,
+        publishLocal in js
       )
       .value,
     scriptedBufferLog := false,

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -1,24 +1,20 @@
 package mdoc.modifiers
 
-import com.ibm.icu.text.RelativeDateTimeFormatter.RelativeDateTimeUnit
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import mdoc.OnLoadContext
 import mdoc.PostProcessContext
 import mdoc.PreModifierContext
-import mdoc.internal.cli.Timer
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.livereload.Resources
 import mdoc.internal.markdown.CodeBuilder
 import mdoc.internal.markdown.Gensym
 import mdoc.internal.markdown.MarkdownCompiler
+import mdoc.internal.pos.PositionSyntax._
 import mdoc.internal.pos.TokenEditDistance
 import org.scalajs.core.tools.io.IRFileCache
 import org.scalajs.core.tools.io.IRFileCache.VirtualRelativeIRFile
 import org.scalajs.core.tools.io.MemVirtualSerializedScalaJSIRFile
 import org.scalajs.core.tools.io.VirtualScalaJSIRFile
 import org.scalajs.core.tools.io.WritableMemVirtualJSFile
-import mdoc.internal.pos.PositionSyntax._
 import org.scalajs.core.tools.linker.Linker
 import org.scalajs.core.tools.linker.StandardLinker
 import org.scalajs.core.tools.logging.Level
@@ -30,7 +26,6 @@ import scala.meta.inputs.Input
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
-import scala.meta.io.RelativePath
 import scala.reflect.io.VirtualDirectory
 
 class JsModifier extends mdoc.PreModifier {

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,13 +1,36 @@
-scalaVersion := "2.12.8"
+scalaVersion.in(ThisBuild) := "2.12.8"
 
 enablePlugins(MdocPlugin)
+mdocJS := Some(jsapp)
 
 TaskKey[Unit]("check") := {
   val obtained = IO.read(mdocOut.value / "readme.md")
-  assert(obtained.trim == """
+  println()
+  println(obtained)
+  println()
+  assert(
+    obtained.trim == """
 ```scala
 println(example.Example.greeting)
 // Hello world!
 ```
-""".trim)
+
+```scala
+println("Hello Scala.js!")
+```
+
+<div id="mdoc-js-run0" data-mdoc-js></div>
+
+<script type="text/javascript" src="readme.md.js" defer></script>
+
+<script type="text/javascript" src="mdoc.js" defer></script>
+""".trim,
+    "\"\"\"\n" + obtained + "\n\"\"\""
+  )
 }
+
+lazy val jsapp = project
+  .settings(
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6"
+  )
+  .enablePlugins(ScalaJSPlugin)

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/docs/readme.md
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/docs/readme.md
@@ -1,3 +1,7 @@
 ```scala mdoc
 println(example.Example.greeting)
 ```
+
+```scala mdoc:js
+println("Hello Scala.js!")
+```

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
@@ -1,2 +1,3 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))
 addSbtCoursier


### PR DESCRIPTION
Using `mdocJS` on 1.1 caused binary compatibility errors.  This commit
adds a scripted test to assert that `mdoc:js` also works.