### PR TITLE
Fix #137, wrap `:fail` in object instead of class.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -13,7 +13,7 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   }
   private def printAsScript(): Unit = {
     sb.println("package repl")
-    sb.println("class Session {")
+    sb.println("object Session {")
     sb.println("  object App {")
     sections.zipWithIndex.foreach {
       case (section, j) =>

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -206,4 +206,30 @@ class FailSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  check(
+    "value-class",
+    """
+      |```scala mdoc
+      |final case class FloatValue(val value: Float) extends AnyVal
+      |```
+      |
+      |```scala mdoc:fail
+      |"abc": Int
+      |```
+    """.stripMargin,
+    """|
+       |```scala
+       |final case class FloatValue(val value: Float) extends AnyVal
+       |```
+       |
+       |```scala
+       |"abc": Int
+       |// error: type mismatch;
+       |//  found   : String("abc")
+       |//  required: Int
+       |// "abc": Int
+       |// ^^^^^
+       |```
+    """.stripMargin
+  )
 }


### PR DESCRIPTION
This was an oversight while transitioning to object wrapping. This is
the price we pay for having separate code generation for `:fail`.