### PR TITLE
Support npm dependencies via scalajs-bundler

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -1,10 +1,11 @@
 ---
 id: js
-title: Scala.js
+title: Scala.js Modifiers
+sidebar_label: Scala.js
 ---
 
-Use the `mdoc:js` modifier to write dynamic and interactive documentation with
-Scala.js.
+Code fences with the `scala mdoc:js` modifier are compiled with Scala.js and
+evaluate on every browser page load providing interactive documentation.
 
 ```scala mdoc:js
 Loading...
@@ -12,17 +13,12 @@ Loading...
 val tick = { () =>
   val date = new scala.scalajs.js.Date()
   val time = s"${date.getHours}h${date.getMinutes}m${date.getSeconds}s"
+  // `node` variable is a DOM element in scope.
   node.innerHTML = s"Current time is $time"
 }
 tick()
 org.scalajs.dom.window.setInterval(tick, 1000)
 ```
-
-Code fences with the `mdoc:js` modifier compile to JavaScript and evaluate at
-HTML load time instead of at markdown generation time.
-
-Each `mdoc:js` code fence has access to a variable `node`, which is an empty DOM
-element.
 
 ## Installation
 
@@ -38,7 +34,7 @@ Next, update the `mdocJS` setting to point to a Scala.js project that has
 
 ```diff
 // build.sbt
-lazy val jsapp = project
+lazy val jsdocs = project
   .settings(
 +   libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6"
   )
@@ -46,7 +42,7 @@ lazy val jsapp = project
 lazy val docs = project
   .in(file("myproject-docs"))
   .settings(
-+   mdocJS := Some(jsapp)
++   mdocJS := Some(jsdocs)
   )
   .enablePlugins(MdocPlugin)
 ```
@@ -108,7 +104,7 @@ Loading <code>:shared</code> example...
 ---
 setInterval(() => {
   val date = new Date().toString()
-  node.innerHTML = s"Shared date $date"
+  node.innerHTML = s"<p>Shared date $date</p>"
 }, 1000)
 ```
 
@@ -166,7 +162,8 @@ println(node.innerHTML)
 ```scala mdoc:js
 <p>I am a custom <code>loader</code></p>
 ---
-println(node.innerHTML) // Open developer console to see this printed message
+// Open developer console to see this printed message
+println(s"Loading HTML: ${node.innerHTML}")
 ```
 
 Replace the node's `innerHTML` to make the HTML disappear once the document has
@@ -180,7 +177,114 @@ org.scalajs.dom.window.setTimeout(() => {
 }, 3000)
 ```
 
-## Generate optimized page
+## Using scalajs-bundler
+
+The [scalajs-bundler](https://scalacenter.github.io/scalajs-bundler/) plugin can
+be used to install npm dependencies and bundle applications with webpack.
+
+Add the following sbt settings if you use scalajs-bundler.
+
+```diff
+ lazy val jsdocs = project
+   .settings(
++    webpackBundlingMode := BundlingMode.LibraryOnly()
++    scalaJSUseMainModuleInitializer := true,
+     npmDependencies.in(Compile) ++= List(
+       // ...
+     ),
+   )
+   .enablePlugins(ScalaJSBundlerPlugin)
+
+ lazy val docs = project
+   .settings(
+     mdocJS := Some(jsdocs),
++    mdocJSLibraries := webpack.in(jsdocs, Compile, fullOptJS).value
+   )
+   .enablePlugins(MdocPlugin)
+```
+
+> The `webpackBundlingMode` must be `LibraryOnly` so that the mdoc generated
+> output can depend on it.
+
+### Bundle npm dependencies
+
+It's important that the main function in `jsdocs` uses the installed npm
+dependencies. If the npm dependencies are not used from the `jsdocs` main
+function, then webpack thinks they are unused and removes them from the bundled
+output even if those dependencies are called from `mdoc:js` markdown code
+fences.
+
+For example, to use the npm [`ms` package](https://www.npmjs.com/package/ms)
+start by writing a facade using `@JSImport`
+
+```scala mdoc:file:tests/jsdocs/src/main/scala/jsdocs/ms.scala
+
+```
+
+Next, write a main function that uses the facade. Make sure that the `jsdocs`
+project contains the setting `scalaJSUseMainModuleInitializer := true`.
+
+```scala mdoc:file:tests/jsdocs/src/main/scala/jsdocs/Main.scala
+
+```
+
+The `ms` function can now be used from `mdoc:js`.
+
+```scala mdoc:js
+val date = new scala.scalajs.js.Date()
+val time = jsdocs.ms(date.getTime())
+node.innerHTML = s"Hello from npm package 'ms': $time"
+```
+
+If the `ms` function is not referenced from the `jsdocs` main function you get a
+stacktrace in the browser console like this:
+
+```js
+Uncaught TypeError: $i_ms is not a function
+    at $c_Lmdocjs$.run6__Lorg_scalajs_dom_raw_Element__V (js.md.js:1180)
+    at js.md.js:3108
+    at mdoc.js:9
+```
+
+### Validate library.js and loader.js
+
+Validate that the `webpack` task provides one `*-library.js` file and one
+`*-loader.js` file.
+
+```scala
+// sbt shell
+> show jsdocs/fullOptJS::webpack
+...
+[info] * Attributed(.../jsdocs/target/scala-2.12/scalajs-bundler/main/jsdocs-opt-loader.js)
+[info] * Attributed(.../jsdocs/target/scala-2.12/scalajs-bundler/main/jsdocs-opt-library.js)
+...
+```
+
+These files are required by mdoc in order to use the scalajs-bundler npm
+dependencies. The files may be missing if you have custom webpack or
+scalajs-bundler configuration. To fix this problem, you may want to try to
+create a new `jsdocs` Scala.js project with minimal webpack and scalajs-bundler
+configuration.
+
+## Configuration
+
+The `mdoc:js` modifier supports several site variable options to customize the
+rendered output of `mdoc:js`.
+
+### Add custom HTML header
+
+Update the `js-html-header` site variable to insert custom HTML before the
+compiled JavaScript. For example, to add React via unpkg add the following
+setting.
+
+```diff
+ mdocVariables := Map(
++  "js-html-header" ->
++     """<script crossorigin src="https://unpkg.com/react@16.5.1/umd/react.production.min.js"></script>"""
+ )
+```
+
+### Generate optimized page
 
 The Scala.js `fullOpt` mode is used by default and the `fastOpt` mode is used
 when the `-w` or `--watch` flag is used. The `fastOpt` mode provides faster
@@ -191,3 +295,52 @@ Update the `js-opt` site variables to override the default optimization mode:
 
 - `js-opt=full`: use `fullOpt` regardless of watch mode
 - `js-opt=fast`: use `fastOpt` regardless of watch mode
+
+### Customize `node` variable name
+
+By default, each `mdoc:js` code fence has access to a `node` variable that
+points to a DOM element.
+
+Update the site variable `js-mount-node=customNode` to use a different variable
+name than `node`.
+
+### Customize output js directory
+
+By default, mdoc generates the javascript next to the output markdown sources.
+For example, a `foo.md` markdown file with `mdoc:js` code fences produces a
+`foo.md.js` JavaScript file in the same directory.
+
+When using the `DocusaurusPlugin` sbt plugin, the output directory is
+automatically configured to emit JavaScript in the `assets/` directory since the
+`docs/` directory can only contain markdown sources.
+
+For other site generators than Docusaurus or outside of sbt, update the site
+variable `js-out-prefix=assets` if you need to generate the output JavaScript
+file in a different directory than the markdown source.
+
+### Customize module kind
+
+By default, sbt-mdoc uses the `scalaJSModuleKind` sbt setting to determine the
+module kind.
+
+Outside of sbt, update the `js-module-kind` site variables to customizee the
+module kind:
+
+- `js-module-kind=NoModule`: don't export modules, the default value.
+- `js-module-kind=CommonJSModule`: use CommonJS modules.
+- `js-module-kind=ESModule`: use ECMAScript modules, not supported.
+
+### Add local JavaScript libraries
+
+In sbt, the `mdocJSLibraries` setting allows you to link local `*-library.js`
+and `*-loader.js` files produced by webpack via scalajs-bundler.
+
+Outside of sbt, update the `js-libraries` site variable to contain a path
+separated list of local JavaScript files (same syntax as Java classpaths) to
+link local JavaScript library files. Note that mdoc will only copy the following
+files:
+
+- `*-library.js`: this file is copied to the output directory and linked from
+  the markdown output as a `<script src="...">`.
+- `*-loader.js`: same as `*-library.js` but it comes after `*-library.js`.
+- `*.js.map`: optional source maps.

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -1,11 +1,11 @@
 ---
 id: modifiers
-title: Modifiers
+title: JVM Modifiers
+sidebar_label: JVM
 ---
 
-Code fences with `scala mdoc` can have different "modifiers", which control how
-the code should be evaluated or rendered. A code fence can only have one
-modifier.
+Code fences with the `scala mdoc` modifier are compiled and evaluated on the JVM
+at markdown generation time.
 
 ## Default
 

--- a/mdoc-docs/src/main/scala/mdoc/docs/FileModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/FileModifier.scala
@@ -3,11 +3,11 @@ package mdoc.docs
 import java.nio.charset.StandardCharsets
 import mdoc.Reporter
 import mdoc.StringModifier
+import mdoc.internal.pos.PositionSyntax._
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
-import mdoc.internal.pos.PositionSyntax._
 
 class FileModifier extends StringModifier {
   val name = "file"
@@ -18,10 +18,15 @@ class FileModifier extends StringModifier {
   ): String = {
     val file = AbsolutePath(info)
     if (file.isFile) {
-      val text = FileIO.slurp(file, StandardCharsets.UTF_8)
+      val text = FileIO.slurp(file, StandardCharsets.UTF_8).trim
+      val language = file.extension match {
+        case "scala" => "scala"
+        case "md" => "md"
+        case _ => "text"
+      }
       s"""
 File: [${file.toNIO.getFileName}](https://github.com/scalameta/mdoc/blob/master/$info)
-`````scala
+`````$language
 $text
 `````
 """

--- a/mdoc-docs/src/main/scala/mdoc/docs/SbtModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/SbtModifier.scala
@@ -16,6 +16,7 @@ class SbtModifier extends StringModifier {
       mdocVariables,
       mdocExtraArguments,
       mdocJS,
+      mdocJSLibraries,
       mdocAutoDependency
     )
     val rows = keys.map { s =>

--- a/mdoc-js/src/main/resources/mdoc.js
+++ b/mdoc-js/src/main/resources/mdoc.js
@@ -1,12 +1,14 @@
 (function(global) {
-  var dom = global.document;
-
   function findDivs() {
-    return Array.from(dom.querySelectorAll("div[data-mdoc-js]"));
+    return Array.from(global.document.querySelectorAll("div[data-mdoc-js]"));
   }
 
-  findDivs().forEach(function(el) {
-    var id = el.getAttribute("id");
-    window[id](el);
-  });
+  function loadAll(scope) {
+    findDivs().forEach(function(el) {
+      var id = el.getAttribute("id");
+      scope[id](el);
+    });
+  }
+
+  loadAll(global);
 })(window);

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
@@ -1,0 +1,105 @@
+package mdoc.modifiers
+
+import mdoc.OnLoadContext
+import mdoc.PostProcessContext
+import mdoc.internal.pos.PositionSyntax._
+import org.scalajs.core.tools.linker.backend.ModuleKind
+import org.scalajs.core.tools.logging.Level
+import scala.meta.internal.io.PathIO
+import scala.meta.io.AbsolutePath
+import scala.meta.io.Classpath
+
+case class JsConfig(
+    moduleKind: ModuleKind = ModuleKind.NoModule,
+    htmlHeader: String = "",
+    libraries: List[AbsolutePath] = Nil,
+    mountNode: String = "node",
+    minLevel: Level = Level.Info,
+    outDirectory: AbsolutePath = PathIO.workingDirectory,
+    fullOpt: Boolean = true,
+    htmlPrefix: String = ""
+) {
+  def isCommonJS: Boolean = moduleKind == ModuleKind.CommonJSModule
+  private def libraryKind(path: AbsolutePath): Int = {
+    val filename = path.filename
+    if (filename.endsWith("-library.js")) 1
+    else if (filename.endsWith("-loader.js")) 2
+    else -1
+  }
+  def libraryScripts(
+      outjsfile: AbsolutePath,
+      ctx: PostProcessContext
+  ): Iterable[String] = {
+    val library = libraries.find(_.filename.endsWith("-library.js"))
+    val loader = libraries.find(_.filename.endsWith("-loader.js"))
+    val sourcemaps = libraries.filter(_.filename.endsWith(".js.map"))
+    val all = List(library.toList, loader.toList, sourcemaps).flatten
+    all.flatMap { lib =>
+      val filename = lib.filename
+      val out = outjsfile.resolveSibling(_ => filename)
+      if (filename.endsWith(".js")) {
+        lib.copyTo(out)
+        val src = out.toRelativeLinkFrom(ctx.outputFile)
+        List(s"""<script type="text/javascript" src="$src" defer></script>""")
+      } else if (filename.endsWith(".js.map")) {
+        lib.copyTo(out)
+        Nil
+      } else {
+        Nil
+      }
+    }
+  }
+}
+
+object JsConfig {
+  def fromVariables(ctx: OnLoadContext): JsConfig = {
+    val base = JsConfig()
+    JsConfig(
+      ctx.site.get("js-module-kind") match {
+        case None => base.moduleKind
+        case Some(value) =>
+          value match {
+            case "NoModule" => ModuleKind.NoModule
+            case "CommonJSModule" => ModuleKind.CommonJSModule
+            case "ESModule" => ModuleKind.ESModule
+            case unknown =>
+              ctx.reporter.error(s"unknown 'js-module-kind': $unknown")
+              base.moduleKind
+          }
+      },
+      ctx.site.getOrElse("js-html-header", ""),
+      Classpath(ctx.site.getOrElse("js-libraries", "")).entries,
+      mountNode = ctx.site.getOrElse("js-mount-node", base.mountNode),
+      outDirectory = ctx.site.get("js-out-prefix") match {
+        case Some(value) =>
+          // This is needed for Docusaurus that requires assets (non markdown) files to live under
+          // `docs/assets/`: https://docusaurus.io/docs/en/doc-markdown#linking-to-images-and-other-assets
+          ctx.settings.out.resolve(value)
+        case None =>
+          ctx.settings.out
+      },
+      minLevel = ctx.site.get("js-level") match {
+        case None => Level.Info
+        case Some("info") => Level.Info
+        case Some("warn") => Level.Warn
+        case Some("error") => Level.Error
+        case Some("debug") => Level.Debug
+        case Some(unknown) =>
+          ctx.reporter.warning(s"unknown 'js-level': $unknown")
+          Level.Info
+      },
+      fullOpt = ctx.site.get("js-opt") match {
+        case None =>
+          !ctx.settings.watch
+        case Some(value) =>
+          value match {
+            case "fast" => false
+            case "full" => true
+            case unknown =>
+              ctx.reporter.error(s"unknown 'js-opt': $unknown")
+              !ctx.settings.watch
+          }
+      }
+    )
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/CodeBuilder.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/CodeBuilder.scala
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets
 class CodeBuilder() {
   private val out = new ByteArrayOutputStream()
   private val ps = new PrintStream(out)
-  def printIf(cond: Boolean, s: String): CodeBuilder = {
+  def printIf(cond: Boolean, s: => String): CodeBuilder = {
     if (cond) print(s)
     else this
   }
@@ -15,16 +15,22 @@ class CodeBuilder() {
     ps.print(s)
     this
   }
-  def printlnIf(cond: Boolean, s: String): CodeBuilder = {
+  def printlnIf(cond: Boolean, s: => String): CodeBuilder = {
     if (cond) println(s)
     else this
+  }
+  def lines(xs: Iterable[String]): CodeBuilder = {
+    xs.iterator.filterNot(_.isEmpty).foreach(println)
+    this
   }
   def foreach[T](xs: Iterable[T])(fn: T => Unit): CodeBuilder = {
     xs.foreach(fn)
     this
   }
   def println(s: String): CodeBuilder = {
-    ps.println(s)
+    if (s.nonEmpty) {
+      ps.println(s)
+    }
     this
   }
 

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -3,6 +3,7 @@ package mdoc.internal.pos
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import scala.meta.Input
 import scala.meta.Position
 import scala.meta.io.AbsolutePath
@@ -10,6 +11,7 @@ import scala.meta.io.RelativePath
 import mdoc.document.RangePosition
 import mdoc.internal.cli.Settings
 import mdoc.internal.markdown.EvaluatedSection
+import scala.meta.internal.io.PathIO
 import scala.util.control.NonFatal
 
 object PositionSyntax {
@@ -173,6 +175,12 @@ object PositionSyntax {
     }
   }
   implicit class XtensionAbsolutePathLink(path: AbsolutePath) {
+    def filename: String = path.toNIO.getFileName.toString
+    def extension: String = PathIO.extension(path.toNIO)
+    def copyTo(out: AbsolutePath): Unit = {
+      Files.createDirectories(path.toNIO.getParent)
+      Files.copy(path.toNIO, out.toNIO, StandardCopyOption.REPLACE_EXISTING)
+    }
     def write(text: String): Unit = {
       Files.createDirectories(path.toNIO.getParent)
       Files.write(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
 libraryDependencies ++= List(
   "org.jsoup" % "jsoup" % "1.11.3",
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/tests/jsdocs/src/main/scala/jsdocs/ExampleJS.scala
+++ b/tests/jsdocs/src/main/scala/jsdocs/ExampleJS.scala
@@ -1,4 +1,4 @@
-package jsapp
+package jsdocs
 
 object ExampleJS {
   val greeting = "Hello!"

--- a/tests/jsdocs/src/main/scala/jsdocs/Main.scala
+++ b/tests/jsdocs/src/main/scala/jsdocs/Main.scala
@@ -1,0 +1,9 @@
+package jsdocs
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    // Important, the main function must use the Scala.js facade in order for
+    // the `ms` npm library to be available from mdoc:js code fences.
+    ms(6000)
+  }
+}

--- a/tests/jsdocs/src/main/scala/jsdocs/ms.scala
+++ b/tests/jsdocs/src/main/scala/jsdocs/ms.scala
@@ -1,0 +1,11 @@
+package jsdocs
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("ms", JSImport.Namespace)
+object ms extends js.Object {
+  // Facade for the npm package `ms` https://www.npmjs.com/package/ms
+  def apply(n: Double): String = js.native
+}

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -16,12 +16,22 @@ import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.meta.testkit.DiffAssertions
 import tests.markdown.StringSyntax._
+import mdoc.internal.pos.PositionSyntax._
 
 abstract class BaseMarkdownSuite extends org.scalatest.FunSuite with DiffAssertions {
-  private val tmp = AbsolutePath(Files.createTempDirectory("mdoc"))
+  def createTempDirectory(): AbsolutePath = {
+    val dir = AbsolutePath(Files.createTempDirectory("mdoc"))
+    dir.toFile.deleteOnExit()
+    dir
+  }
+  def createTempFile(filename: String): AbsolutePath = {
+    val file = createTempDirectory().resolve(filename)
+    file.write("")
+    file
+  }
   protected def baseSettings: Settings =
     Settings
-      .default(tmp)
+      .default(createTempDirectory())
       .copy(
         site = Map(
           "version" -> "1.0"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -15,13 +15,12 @@
         "title": "Installation"
       },
       "js": {
-        "title": "Scala.js"
+        "title": "Scala.js Modifiers",
+        "sidebar_label": "Scala.js"
       },
       "modifiers": {
-        "title": "Modifiers"
-      },
-      "readme": {
-        "title": "readme"
+        "title": "JVM Modifiers",
+        "sidebar_label": "JVM"
       },
       "tut": {
         "title": "Coming from tut"
@@ -36,7 +35,9 @@
       "GitHub": "GitHub"
     },
     "categories": {
-      "Overview": "Overview"
+      "Overview": "Overview",
+      "Modifiers": "Modifiers",
+      "Site generators": "Site generators"
     }
   },
   "pages-strings": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,7 @@
 {
   "docs": {
-    "Overview": ["installation", "modifiers", "why", "tut", "docusaurus", "js"]
+    "Overview": ["installation", "why", "tut"],
+    "Modifiers": ["modifiers", "js"],
+    "Site generators": ["docusaurus"]
   }
 }


### PR DESCRIPTION
Fixes #133.

Previously, the `mdoc:js` modifier worked only with plain Scala
projects. After this commit, it's possible to call npm libraries from
`mdoc:js` by using scalajs-bundler. Adding this feature requires
several changes:

- extract `scalaJSModuleKind` from the build to emit CommonJS modules
- extract webpack generated libraries from the build
- customize rendered markdown when using CommonJS modules