### PR TITLE
Preserve original formatting of frontmatter blocks

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -1,5 +1,6 @@
 package mdoc.internal.cli
 
+import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.options.MutableDataSet
 import io.methvin.watcher.DirectoryChangeEvent
 import java.nio.file.Files

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MdocExtensions.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MdocExtensions.scala
@@ -4,7 +4,6 @@ import com.vladsch.flexmark.Extension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.definition.DefinitionExtension
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
-import com.vladsch.flexmark.ext.footnotes.FootnoteExtension
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
 import com.vladsch.flexmark.ext.ins.InsExtension
 import com.vladsch.flexmark.ext.tables.TablesExtension

--- a/tests/unit/src/test/scala/tests/markdown/FrontmatterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FrontmatterSuite.scala
@@ -1,5 +1,13 @@
 package tests.markdown
 
+import com.vladsch.flexmark.ext.jekyll.front.matter.JekyllFrontMatterExtension
+import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.options.MutableDataSet
+import mdoc.internal.markdown.Markdown
+import scala.collection.JavaConverters._
+
 class FrontmatterSuite extends BaseMarkdownSuite {
 
   check(
@@ -22,38 +30,23 @@ class FrontmatterSuite extends BaseMarkdownSuite {
       |""".stripMargin
   )
 
-  val deep =
-    check(
-      "deep",
-      """
-        |---
-        |title: Use isNaN when checking for NaN
-        |layout: article
-        |linters:
-        |  - name: linter
-        |    rules:
-        |      - name: UseIsNanNotNanComparison
-        |        url:  https://github.com/HairyFotr/linter/blob/master/src/test/scala/LinterPluginTest.scala#L1930
-        |  - name: scapegoat
-        |    rules:
-        |      - name: NanComparison
-        |---
-    """.stripMargin,
-      """|---
-         |
-         |title: Use isNaN when checking for NaN
-         |layout: article
-         |linters:
-         |- name: linter
-         |  rules:
-         |  - name: UseIsNanNotNanComparison
-         |    url:  https://github.com/HairyFotr/linter/blob/master/src/test/scala/LinterPluginTest.scala#L1930
-         |- name: scapegoat
-         |  rules:
-         |  - name: NanComparison
-         |
-         |---
+  val nested =
+    """|---
+       |title: Use isNaN when checking for NaN
+       |layout: article
+       |linters:
+       |  - name: linter
+       |    rules:
+       |      - name: UseIsNanNotNanComparison
+       |        url:  https://github.com/HairyFotr/linter/blob/master/src/test/scala/LinterPluginTest.scala#L1930
+       |  - name: scapegoat
+       |    rules:
+       |      - name: NanComparison
+       |---
+       |
+       |# Title
     """.stripMargin
-    )
+  // See https://github.com/vsch/flexmark-java/issues/293
+  check("nested", nested, nested)
 
 }


### PR DESCRIPTION
Reported upstream in flexmark https://github.com/vsch/flexmark-java/issues/293

Thanks for reporting @nrinaudo