### PR TITLE
Filter out non-section warnings in fail blocks, fixes #151.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -138,7 +138,7 @@ class MarkdownCompiler(
     new BatchSourceFile(filename, new String(input.chars))
   }
 
-  def fail(original: Seq[Tree], input: Input): String = {
+  def fail(original: Seq[Tree], input: Input, sectionPos: Position): String = {
     sreporter.reset()
     val run = new global.Run
     run.compileSources(List(toSource(input)))
@@ -149,9 +149,11 @@ class MarkdownCompiler(
       case sreporter.Info(pos, msgOrNull, gseverity) =>
         val msg = nullableMessage(msgOrNull)
         val mpos = toMetaPosition(edit, pos)
-        val severity = gseverity.toString().toLowerCase
-        val formatted = PositionSyntax.formatMessage(mpos, severity, msg, includePath = false)
-        ps.println(formatted)
+        if (sectionPos.contains(mpos) || gseverity == sreporter.ERROR) {
+          val severity = gseverity.toString().toLowerCase
+          val formatted = PositionSyntax.formatMessage(mpos, severity, msg, includePath = false)
+          ps.println(formatted)
+        }
     }
     out.toString()
   }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -133,8 +133,11 @@ object Renderer {
                 sb.append('\n')
                 binder.value match {
                   case FailSection(instrumented, startLine, startColumn, endLine, endColumn) =>
-                    val compiled =
-                      compiler.fail(doc.sections.map(_.source), Input.String(instrumented))
+                    val compiled = compiler.fail(
+                      doc.sections.map(_.source),
+                      Input.String(instrumented),
+                      section.source.pos
+                    )
                     if (compiled.isEmpty) {
                       val tpos = new RangePosition(startLine, startColumn, endLine, endColumn)
                       reporter.error(

--- a/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
@@ -123,4 +123,47 @@ class ScalacOptionsSuite extends BaseCliSuite {
     )
   )
 
+  // see https://github.com/scalameta/mdoc/issues/151
+  checkCli(
+    "dead-fail",
+    """
+      |/index.md
+      |```scala mdoc
+      |final case class Test(value: Int)
+      |
+      |val test = Test(123)
+      |
+      |test.value
+      |```
+      |
+      |```scala mdoc:fail
+      |val x: Int = "123"
+      |```
+      |""".stripMargin,
+    """|/index.md
+       |```scala
+       |final case class Test(value: Int)
+       |
+       |val test = Test(123)
+       |// test: Test = Test(123)
+       |
+       |test.value
+       |// res0: Int = 123
+       |```
+       |
+       |```scala
+       |val x: Int = "123"
+       |// error: type mismatch;
+       |//  found   : String("123")
+       |//  required: Int
+       |// val x: Int = "123"
+       |//              ^^^^^
+       |```
+       |""".stripMargin,
+    extraArgs = Array(
+      "--scalac-options",
+      "-Ywarn-value-discard"
+    )
+  )
+
 }


### PR DESCRIPTION
Previously, we printed out all reported diagnostics for `:fail` blocks
even if those diagnostics came from non-fail blocks. This commit changes
the scheme so we only print diagnostics that origin from the fail block.