### PR TITLE
Automatically restart compiler when classfiles are missing.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -73,7 +73,8 @@ case class Settings(
       "Compiler flags such as compiler plugins '-Xplugin:kind-projector.jar' " +
         "or custom options '-deprecated'. Formatted as a single string with space separated values. " +
         "To pass multiple values: --scalac-options \"-Yrangepos -deprecated\". " +
-        "Defaults to the value of 'scalacOptions' in the 'mdoc.properties' resource file, if any."
+        "Defaults to the value of 'scalacOptions' in the 'mdoc.properties' resource file, if any. " +
+        "When using sbt-mdoc, update the `scalacOptions` sbt setting instead of passing --scalac-options to `mdocExtraArguments`."
     )
     scalacOptions: String = "",
     @Description("Remove all files in the output directory before generating a new site.")


### PR DESCRIPTION
Previously, mdoc reused the same compiler instance for all compilations.
Now, we create a new compiler instance when the following situation
happens:

- compilation succeeds without any reported errors
- compilation produced no classfiles

I've consistently been able to reproduce this situation in the
https://github.com/spotify/scio repo when running mdoc on all the
markdown sources but I haven't been able to minimize the error to a
single source file. In Metals we restart the compiler frequently to
avoid cryptic errors like this. The compiler has a lot of state that
tends to go bad after several repeated compile requests, especially when
macro annotations are involved.

Fixes #164.