### PR TITLE
Reset compiler on every run.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -177,6 +177,7 @@ class MarkdownCompiler(
       className: String,
       retry: Int = 0
   ): Option[Class[_]] = {
+    reset()
     compileSources(input, vreporter, edit)
     if (!sreporter.hasErrors) {
       val loader = new AbstractFileClassLoader(target, appClassLoader)


### PR DESCRIPTION
Previously, we reused the same compiler instance between compilations
which could cause cryptic errors due to stale state in the compiler.
Now, we create a new compiler instance for every compilation.

The overhead to create a new compiler is ~150ms in my measurements,
which is not great but manageable.