### PR TITLE
Expose custom `println` in scope that captures output from all threads

### DIFF
--- a/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
@@ -21,6 +21,12 @@ trait DocumentBuilder {
   private var statementPosition = RangePosition.empty
   private var lastPosition = RangePosition.empty
 
+  def print(obj: Any): Unit = {
+    myPs.print(if (null == obj) "null" else obj.toString())
+  }
+  def println(): Unit = myPs.println()
+  def println(x: Any): Unit = myPs.println(x)
+
   object $doc {
 
     def position(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int): RangePosition = {

--- a/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
@@ -78,4 +78,37 @@ class AsyncSuite extends BaseMarkdownSuite {
        |```
     """.stripMargin
   )
+
+  check(
+    "println",
+    """
+      |```scala mdoc:reset-class
+      |import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+      |val done = scala.concurrent.Promise[Unit]()
+      |global.execute(new Runnable {
+      |  override def run(): Unit = {
+      |    Thread.sleep(20)
+      |    println("Hello from other thread!")
+      |    done.success(())
+      |  }
+      |})
+      |Await.result(done.future, Duration("100ms"))
+      |```
+    """.stripMargin,
+    """|```scala
+       |import scala.concurrent._, duration._, ExecutionContext.Implicits.global
+       |val done = scala.concurrent.Promise[Unit]()
+       |// done: Promise[Unit] = Future(Success(()))
+       |global.execute(new Runnable {
+       |  override def run(): Unit = {
+       |    Thread.sleep(20)
+       |    println("Hello from other thread!")
+       |    done.success(())
+       |  }
+       |})
+       |Await.result(done.future, Duration("100ms"))
+       |// Hello from other thread!
+       |```
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
Previously, writing `println()` in an mdoc code fence would not get
captured if it was running in a separate thread.  Now, we expose a
custom `println` method in scope that uses mdoc's output stream
regardless of the running thread.

FYI @tpolecat @baccata