### PR TITLE
Fix Docusaurus publishing scaladocs instructions

### DIFF
--- a/docs/docusaurus.md
+++ b/docs/docusaurus.md
@@ -195,6 +195,7 @@ You can configure a project to include Scaladocs in its site. Below is an exampl
 +      target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",
 +      cleanFiles += (target in (ScalaUnidoc, unidoc)).value,
 +      docusaurusCreateSite := docusaurusCreateSite.dependsOn(unidoc in Compile).value,
++      docusaurusPublishGhpages := docusaurusPublishGhpages.dependsOn(unidoc in Compile).value,
    )
 -  .enablePlugins(MdocPlugin, DocusaurusPlugin)
 +  .enablePlugins(MdocPlugin, DocusaurusPlugin, ScalaUnidocPlugin)


### PR DESCRIPTION
I previously had assumed that `docusaurusPublishGhpages` depended on
`docusaurusCreateSite`, but this appears to not be the case. I'm not
sure whether or not that should be changed, but in the absence of that
changing, this should fix publishing without first running
`docusaurusCreateSite`.