### PR TITLE
Process HTML files like markdown files, fixes #199.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -85,9 +85,11 @@ final class MainOps(
     try {
       if (!settings.isIncluded(file.relpath)) Exit.success
       else {
-        PathIO.extension(file.in.toNIO) match {
-          case "md" => handleMarkdown(file)
-          case _ => handleRegularFile(file)
+        val extension = PathIO.extension(file.in.toNIO)
+        if (settings.isMarkdownFileExtension(extension)) {
+          handleMarkdown(file)
+        } else {
+          handleRegularFile(file)
         }
       }
     } catch {

--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -96,6 +96,8 @@ case class Settings(
     usage: Boolean = false,
     @Description("Print out the version number and exit")
     version: Boolean = false,
+    @Description("Set of file extensions to treat as markdown files.")
+    markdownExtensions: List[String] = List("md", "html"),
     @Description(
       "Glob to filter which files to process. Defaults to all files. " +
         "Example: --include **/example.md will process only files with the name example.md."
@@ -134,6 +136,8 @@ case class Settings(
     @Description("The pretty printer for variables")
     variablePrinter: Variable => String = ReplVariablePrinter
 ) {
+
+  val isMarkdownFileExtension = markdownExtensions.toSet
 
   def withProperties(props: MdocProperties): Settings =
     copy(

--- a/tests/unit/src/test/scala/tests/cli/CliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/CliSuite.scala
@@ -168,4 +168,27 @@ class CliSuite extends BaseCliSuite {
     }
   )
 
+  checkCli(
+    "html",
+    """
+      |/index.html
+      |<h1>My Fantastic Talk!</h1>
+      |<p>
+      |```scala mdoc
+      |println(42)
+      |```
+      |</p>
+      |""".stripMargin,
+    """
+      |/index.html
+      |<h1>My Fantastic Talk!</h1>
+      |<p>
+      |```scala
+      |println(42)
+      |// 42
+      |```
+      |</p>
+      |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Previously, we only processed `*.md` files. Now we also process `*.html`
files so that it's possible to use mdoc for writing Reveal.js slides.