### PR TITLE
Add support and tests for Literal type syntax

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
@@ -13,6 +13,7 @@ import mdoc.PostProcessContext
 import mdoc.PreModifierContext
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
+import scala.meta.dialects.Scala213
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 import mdoc.internal.cli.Context
@@ -21,6 +22,14 @@ import mdoc.internal.markdown.Modifier._
 import mdoc.internal.pos.PositionSyntax._
 import pprint.TPrintColors
 import scala.meta.io.RelativePath
+
+object MdocDialect {
+
+  val scala = Scala213.copy(
+    allowToplevelTerms = true,
+    toplevelSeparator = ""
+  )
+}
 
 class Processor(implicit ctx: Context) {
 
@@ -103,8 +112,7 @@ class Processor(implicit ctx: Context) {
     val sectionInputs = inputs.map {
       case ScalaFenceInput(_, input, mod) =>
         import scala.meta._
-        val sbt1WithLiteralTypes = dialects.Sbt1.copy(allowLiteralTypes = true)
-        sbt1WithLiteralTypes(input).parse[Source] match {
+        MdocDialect.scala(input).parse[Source] match {
           case parsers.Parsed.Success(source) =>
             SectionInput(input, source, mod)
           case parsers.Parsed.Error(pos, msg, _) =>

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
@@ -103,7 +103,8 @@ class Processor(implicit ctx: Context) {
     val sectionInputs = inputs.map {
       case ScalaFenceInput(_, input, mod) =>
         import scala.meta._
-        dialects.Sbt1(input).parse[Source] match {
+        val sbt1WithLiteralTypes = dialects.Sbt1.copy(allowLiteralTypes = true)
+        sbt1WithLiteralTypes(input).parse[Source] match {
           case parsers.Parsed.Success(source) =>
             SectionInput(input, source, mod)
           case parsers.Parsed.Error(pos, msg, _) =>

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -24,10 +24,9 @@ object Renderer {
       filename: String,
       printer: Variable => String
   ): String = {
-    val sbt1WithLiteralTypes = dialects.Sbt1.copy(allowLiteralTypes = true)
     val inputs =
       sections.map(
-        s => SectionInput(s, sbt1WithLiteralTypes(s).parse[Source].get, Modifier.Default())
+        s => SectionInput(s, MdocDialect.scala(s).parse[Source].get, Modifier.Default())
       )
     val instrumented = Instrumenter.instrument(inputs)
     val doc =

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -24,8 +24,9 @@ object Renderer {
       filename: String,
       printer: Variable => String
   ): String = {
+    val sbt1WithLiteralTypes = dialects.Sbt1.copy(allowLiteralTypes = true)
     val inputs =
-      sections.map(s => SectionInput(s, dialects.Sbt1(s).parse[Source].get, Modifier.Default()))
+      sections.map(s => SectionInput(s, sbt1WithLiteralTypes(s).parse[Source].get, Modifier.Default()))
     val instrumented = Instrumenter.instrument(inputs)
     val doc =
       MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented, filename)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -26,7 +26,9 @@ object Renderer {
   ): String = {
     val sbt1WithLiteralTypes = dialects.Sbt1.copy(allowLiteralTypes = true)
     val inputs =
-      sections.map(s => SectionInput(s, sbt1WithLiteralTypes(s).parse[Source].get, Modifier.Default()))
+      sections.map(
+        s => SectionInput(s, sbt1WithLiteralTypes(s).parse[Source].get, Modifier.Default())
+      )
     val instrumented = Instrumenter.instrument(inputs)
     val doc =
       MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented, filename)

--- a/tests/unit/src/test/scala-2.13/tests/markdown/LiteralTypesSuite.scala
+++ b/tests/unit/src/test/scala-2.13/tests/markdown/LiteralTypesSuite.scala
@@ -1,0 +1,61 @@
+package tests.markdown
+
+class LiteralTypesSuite extends BaseMarkdownSuite {
+
+  check(
+    "val declaration",
+    """
+      |```scala mdoc
+      |val one: 1 = 1
+      |```
+    """.stripMargin,
+    """|```scala
+       |val one: 1 = 1
+       |// one: Int = 1
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "param type, type arg",
+    """
+      |```scala mdoc
+      |def foo(x: 1): Option[1] = Some(x)
+      |```
+    """.stripMargin,
+    """|```scala
+       |def foo(x: 1): Option[1] = Some(x)
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "type parameter bound",
+    """
+      |```scala mdoc
+      |def bar[T <: 1](t: T): T = t
+      |```
+    """.stripMargin,
+    """|```scala
+       |def bar[T <: 1](t: T): T = t
+       |```
+    """.stripMargin
+  )
+
+  check(
+    "type ascription",
+    """
+      |```scala mdoc
+      |def foo(x: Int): Int = x
+      |foo(1: 1)
+      |```
+    """.stripMargin,
+    """|```scala
+       |def foo(x: Int): Int = x
+       |foo(1: 1)
+       |// res0: Int = 1
+       |```
+    """.stripMargin
+  )
+
+}


### PR DESCRIPTION
**This PR is a work in progress**
The first commit adds a new suite of tests, `LiteralTypesSuite`, which tests literal type syntax using the examples provided in the [SIP-23 document](https://docs.scala-lang.org/sips/42.type.html#proposal-details). This test suite currently fails on latest master (92b66b5).

The second commit implements a somewhat hacky "fix" for this test suite by manually adding `allowLiteralTypes = true` to the `Sbt1` dialect that gets used.

**Advice needed**
Perhaps a more desirable fix is to change upstream [Scalameta's `Sbt1` dialect](https://github.com/scalameta/scalameta/blob/v4.2.2/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala#L208) to copy from `Scala213` instead of `Scala212`. Or to allow users of `mdoc` to specify a dialect manually. I'm happy to do the leg work, but I am not sure what kind of solution the authors would prefer.