### PR TITLE
Add test with returned literal type

### DIFF
--- a/tests/unit/src/test/scala-2.13/tests/markdown/LiteralTypesSuite.scala
+++ b/tests/unit/src/test/scala-2.13/tests/markdown/LiteralTypesSuite.scala
@@ -58,4 +58,20 @@ class LiteralTypesSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  check(
+    "narrowing",
+    """
+      |```scala mdoc
+      |def narrower[T <: Singleton](t: T): T {} = t
+      |narrower(42)
+      |```
+    """.stripMargin,
+    """|```scala
+       |def narrower[T <: Singleton](t: T): T {} = t
+       |narrower(42)
+       |// res0: 42 = 42
+       |```
+    """.stripMargin
+  )
+
 }


### PR DESCRIPTION
This tiny PR extends the `LiteralTypesSuite` to include a test that returns a literal type and shows that `mdoc` properly print this.