### PR TITLE
Use HTMLElement for mdoc:js modifier `node` variable

### DIFF
--- a/mdoc-js/src/main/scala-2.12/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala-2.12/mdoc/modifiers/JsModifier.scala
@@ -211,7 +211,9 @@ class JsModifier extends mdoc.PreModifier {
       } else {
         new CodeBuilder()
           .println(s""" @_root_.scala.scalajs.js.annotation.JSExportTopLevel("$id") """)
-          .println(s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.Element): Unit = {""")
+          .println(
+            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {"""
+          )
           .println(input.text)
           .println("}")
           .toString

--- a/tests/unit/src/test/scala-2.12/tests/markdown/JsSuite.scala
+++ b/tests/unit/src/test/scala-2.12/tests/markdown/JsSuite.scala
@@ -223,6 +223,15 @@ class JsSuite extends BaseMarkdownSuite {
     """.stripMargin
   )
 
+  checkCompiles(
+    "onclick",
+    """
+      |```scala mdoc:js
+      |node.onclick = {_ => println(42)}
+      |```
+    """.stripMargin
+  )
+
   checkError(
     "no-dom",
     """
@@ -231,7 +240,7 @@ class JsSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """|error: no-dom.md:3 (mdoc generated code) object scalajs is not a member of package org
-       |def run0(node: _root_.org.scalajs.dom.raw.Element): Unit = {
+       |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
        |                          ^
     """.stripMargin,
     settings = {


### PR DESCRIPTION
Previously, it was not possible to call methods like `node.onclick`
because it was typed as `Element`