### PR TITLE
Return partially evaluated documents on exceptions.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -52,8 +52,9 @@ object MarkdownCompiler {
         try {
           doc.build(instrumentedInput)
         } catch {
-          case e: PositionedException =>
-            val input = sectionInputs(e.section).input
+          case e: DocumentException =>
+            val index = e.sections.length - 1
+            val input = sectionInputs(index).input
             val pos =
               if (e.pos.isEmpty) {
                 Position.Range(input, 0, 0)
@@ -68,7 +69,7 @@ object MarkdownCompiler {
                 slice.toUnslicedPosition
               }
             reporter.error(pos, e.getCause)
-            Document.empty(instrumentedInput)
+            Document(instrumentedInput, e.sections)
           case MdocNonFatal(e) =>
             reporter.error(e)
             Document.empty(instrumentedInput)

--- a/runtime/src/main/scala/mdoc/document/DocumentException.scala
+++ b/runtime/src/main/scala/mdoc/document/DocumentException.scala
@@ -2,9 +2,8 @@ package mdoc.document
 
 import scala.util.control.NoStackTrace
 
-@deprecated("Use DocumentException instead", "2.1.1")
-final class PositionedException(
-    val section: Int,
+final class DocumentException(
+    val sections: List[Section],
     val pos: RangePosition,
     val cause: Throwable
 ) extends Exception(pos.toString, cause)

--- a/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
@@ -84,8 +84,10 @@ trait DocumentBuilder {
         }
       } catch {
         case MdocNonFatal(e) =>
+          endStatement()
+          endSection()
           MdocExceptions.trimStacktrace(e)
-          throw new PositionedException(mySections.length, lastPosition, e)
+          throw new DocumentException(mySections.toList, lastPosition, e)
       }
       val document = Document(input, mySections.toList)
       mySections.clear()

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -30,7 +30,6 @@ class WorksheetSuite extends FunSuite with BeforeAndAfterAll with DiffAssertions
     test(name) {
       val filename = name + ".scala"
       val worksheet = mdoc.evaluateWorksheet(filename, original)
-      assert(worksheet.statements.isEmpty, worksheet.statements)
       val input = Input.VirtualFile(name, original)
       val out = new StringBuilder()
       var i = 0
@@ -65,9 +64,6 @@ class WorksheetSuite extends FunSuite with BeforeAndAfterAll with DiffAssertions
       val input = Input.VirtualFile(name, original)
       val out = new StringBuilder()
       var i = 0
-      val hasErrors =
-        worksheet.diagnostics().asScala.exists(_.severity() == DiagnosticSeverity.Error)
-      require(!hasErrors, worksheet.diagnostics())
       statements.foreach { stat =>
         val p = Position.Range(
           input,
@@ -228,6 +224,19 @@ class WorksheetSuite extends FunSuite with BeforeAndAfterAll with DiffAssertions
        |
        |crash(filename)
        |^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+
+  checkDecorations(
+    "partial-exception",
+    """
+      |val x = "foobar".stripSuffix("bar")
+      |throw new RuntimeException("boom")
+      |val y = "foobar".stripSuffix("bar")
+      |""".stripMargin,
+    """|
+       |<val x = "foobar".stripSuffix("bar")> // "foo"
+       |x: String = "foo"
        |""".stripMargin
   )
 


### PR DESCRIPTION
Previously, an exception during worksheet evaluation would result in
partially evaluated documents. Now, we return as many evaluated
expressions a possible even if the document crashed during evaluation.

Fixes https://github.com/scalameta/metals/issues/1229

Example how worksheets look now with partially evaluated documents
<img width="832" alt="Screenshot 2020-01-02 at 00 02 20" src="https://user-images.githubusercontent.com/1408093/71647197-2b19af00-2cf3-11ea-9693-19342a9934b3.png">
