### PR TITLE
scala-js-dom 0.9.7 is required to work with recent versions of Scalaj…

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -80,7 +80,7 @@ Next, update the `mdocJS` setting to point to a Scala.js project that has
 // build.sbt
 lazy val jsdocs = project
   .settings(
-+   libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6"
++   libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.7"
   )
   .enablePlugins(ScalaJSPlugin)
 lazy val docs = project


### PR DESCRIPTION
…s/2.13.x