### PR TITLE
Fix heading for 'command-line'

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,6 +119,7 @@ The sbt-mdoc plugin supports the following settings.
 
 ```
 
+
 ## Command-line
 
 Use [coursier](https://github.com/coursier/coursier/#command-line) to launch


### PR DESCRIPTION
Before this change `## Command-line` wasn't recognized as a headline, which breaks
the link in the sidebar and  prevents proper formatting of the headline.

The reason seems to be `scala mdoc:sbt` before absorbs the empty line between the code block 
the heading.