### PR TITLE
Improve CLI --classpath option documentation

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -68,7 +68,7 @@ case class Settings(
       "Classpath to use when compiling Scala code examples. " +
         "Defaults to the current thread's classpath." +
         "You can use Coursier's fetch command to generate the classpath for you:" +
-        "`--classpath $(cs fetch org::artifact:version | tr '\n' ':')`"
+        "`--classpath $(cs fetch --classpath org::artifact:version)`"
     )
     classpath: String = "",
     @Description(

--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -66,7 +66,9 @@ case class Settings(
     @Section("Compiler options")
     @Description(
       "Classpath to use when compiling Scala code examples. " +
-        "Defaults to the current thread's classpath."
+        "Defaults to the current thread's classpath." +
+        "You can use Coursier's fetch command to generate the classpath for you:" +
+        "`--classpath $(cs fetch org::artifact:version | tr '\n' ':')`"
     )
     classpath: String = "",
     @Description(


### PR DESCRIPTION
When running with the `mdoc` executable directly, you can specify the classpath
directly. I rarely set the java/scala `-cp` flag directly so I did not really
know the syntax (`:` as a separator between the jars). So when I found out I
could use coursier's fetch command to build the classpath, I figured somebody
else would like to know.

The command produce an output like this:

```
cs fetch co.fs2::fs2-io:2.2.2 | tr '\n' ':'
/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/co/fs2/fs2-io_2.13/2.2.2/fs2-io_2.13-2.2.2.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/co/fs2/fs2-core_2.13/2.2.2/fs2-core_2.13-2.2.2.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.13/2.1.0/cats-core_2.13-2.1.0.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/typelevel/cats-effect_2.13/2.0.0/cats-effect_2.13-2.0.0.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scodec/scodec-bits_2.13/1.1.12/scodec-bits_2.13-1.1.12.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/typelevel/cats-macros_2.13/2.1.0/cats-macros_2.13-2.1.0.jar:/Users/david/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.1.0/cats-kernel_2.13-2.1.0.jar
```