### PR TITLE
Don't include nest sections in fail sections

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -17,7 +17,7 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
     sb.println("  object App {")
     sections.zipWithIndex.foreach {
       case (section, j) =>
-        if (j > i) ()
+        if (j > i || section.mod.isNest) ()
         else {
           if (section.mod.isReset) {
             sb.print(Instrumenter.reset(section.mod, gensym.fresh("App")))

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -231,4 +231,29 @@ class FailSuite extends BaseMarkdownSuite {
        |```
     """.stripMargin
   )
+
+  check(
+    "after-nest",
+    """
+      |```scala mdoc:nest
+      |case class Foo(i: Int)
+      |```
+      |
+      |```scala mdoc:fail
+      |case class Foo(i: Int) { val x = y }
+      |```
+    """.stripMargin,
+    """|
+       |```scala
+       |case class Foo(i: Int)
+       |```
+       |
+       |```scala
+       |case class Foo(i: Int) { val x = y }
+       |// error: not found: value y
+       |// case class Foo(i: Int) { val x = y }
+       |//                                  ^
+       |```
+    """.stripMargin
+  )
 }


### PR DESCRIPTION
I'm running into an issue with a block marked `fail` that also includes definitions that clash with definitions from previous `nest` blocks:
````markdown
```scala mdoc:nest
case class Foo(i: Int)
```
```scala mdoc:fail
case class Foo(i: Int) { val x = y }
```
````
I want the output to include the `not found: value y` error, and it does, but it also includes this:
```markdown
// error: Foo is already defined as case class Foo
// case class Foo(i: Int) { val x = y }
// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
I've added a test (that fails on master) and fixed the issue by not including any preceding `nest` blocks in the `fail` instrumenter. This seems reasonable to me, but I'm not familiar with this code and would be happy to look into other approaches if I'm missing something!