### PR TITLE
Respect nest modifier in fail instrumenter.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -7,6 +7,7 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private val out = new ByteArrayOutputStream()
   private val sb = new PrintStream(out)
   private val gensym = new Gensym()
+  private val nest = new Nesting(sb)
   def instrument(): String = {
     printAsScript()
     out.toString
@@ -20,7 +21,10 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
         if (j > i) ()
         else {
           if (section.mod.isReset) {
+            nest.unnest()
             sb.print(Instrumenter.reset(section.mod, gensym.fresh("App")))
+          } else if (section.mod.isNest) {
+            nest.nest()
           }
           if (j == i || !section.mod.isFail) {
             sb.println(section.input.text)
@@ -28,5 +32,6 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
         }
     }
     sb.println("\n  }\n}")
+    nest.unnest()
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
@@ -16,25 +16,15 @@ class Instrumenter(sections: List[SectionInput]) {
   private val out = new ByteArrayOutputStream()
   private val sb = new PrintStream(out)
   val gensym = new Gensym()
-  private var nestCount = 0
-  private def nest(): Unit = {
-    nestCount += 1
-    sb.append(s"_root_.scala.Predef.locally {\n")
-  }
-  private def unnest(): Unit = {
-    1.to(nestCount).foreach { _ =>
-      sb.print("};")
-    }
-    nestCount = 0
-  }
+  val nest = new Nesting(sb)
   private def printAsScript(): Unit = {
     sections.zipWithIndex.foreach {
       case (section, i) =>
         if (section.mod.isReset) {
-          unnest()
+          nest.unnest()
           sb.print(Instrumenter.reset(section.mod, gensym.fresh("App")))
         } else if (section.mod.isNest) {
-          nest()
+          nest.nest()
         }
         sb.println("\n$doc.startSection();")
         if (section.mod.isFail) {
@@ -68,7 +58,7 @@ class Instrumenter(sections: List[SectionInput]) {
         }
         sb.println("$doc.endSection();")
     }
-    unnest()
+    nest.unnest()
   }
 
   private def printBinder(name: String, pos: Position): Unit = {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Nesting.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Nesting.scala
@@ -1,0 +1,17 @@
+package mdoc.internal.markdown
+
+import java.io.PrintStream
+
+class Nesting(sb: PrintStream) {
+  private var nestCount = 0
+  def nest(): Unit = {
+    nestCount += 1
+    sb.append(s"_root_.scala.Predef.locally {\n")
+  }
+  def unnest(): Unit = {
+    1.to(nestCount).foreach { _ =>
+      sb.print("};")
+    }
+    nestCount = 0
+  }
+}

--- a/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
@@ -275,4 +275,29 @@ class NestSuite extends BaseMarkdownSuite {
        |""".stripMargin
   )
 
+  check(
+    "fail",
+    """
+      |```scala mdoc
+      |case class Foo(i: Int)
+      |```
+      |
+      |```scala mdoc:nest:fail
+      |case class Foo(i: Int) { val x = y }
+      |```
+    """.stripMargin,
+    """|
+       |```scala
+       |case class Foo(i: Int)
+       |```
+       |
+       |```scala
+       |case class Foo(i: Int) { val x = y }
+       |// error: not found: value y
+       |// case class Foo(i: Int) { val x = y }
+       |//                                  ^
+       |```
+    """.stripMargin
+  )
+
 }


### PR DESCRIPTION
Alternative approach to https://github.com/scalameta/mdoc/pull/305.

Previously, the fail and nest modifiers didn't play nicely together.
Now, the fail instrumenter respects nest modifiers so that the two
modifiers can be combined in the same code fence.