### PR TITLE
Add in maven-central badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/scalameta/mdoc.svg?branch=master)](https://travis-ci.org/scalameta/mdoc)
 [![Join the chat at https://gitter.im/scalameta/mdoc](https://badges.gitter.im/scalameta/mdoc.svg)](https://gitter.im/scalameta/mdoc)
+![Maven Central](https://img.shields.io/maven-central/v/org.scalameta/mdoc_2.13)
 
 mdoc is a markdown documentation tool for Scala inspired by
 [tut](https://github.com/tpolecat/tut). Visit https://scalameta.org/mdoc to


### PR DESCRIPTION
This a small pr that just adds in a maven central badge to pull in the latest version and display it on the readme.

Whenever I check latest versions I always default to checking the github page. This just saves me a step to not have to click into the site and find it there.