### PR TITLE
Add support for adding library dependencies via imports.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         command:
           - "'++2.11.12 test'"
           - "'++2.12.11 test' scripted"
-          - "'++2.13.1 test'"
+          - "'++2.13.2 test'"
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,210 @@
+# License notice for Coursier
+
+MUnit contains parts which are derived from
+[Coursier](https://github.com/coursier/coursier). We include the
+text of the original license below:
+````
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+````
+

--- a/mdoc-docs/src/main/scala/mdoc/docs/MdocModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/MdocModifier.scala
@@ -25,7 +25,7 @@ class MdocModifier(context: Context) extends StringModifier {
     myStdout.reset()
     myReporter.reset()
     val cleanInput = Input.VirtualFile(code.filename, code.text)
-    val file = InputFile.fromSettings(code.filename, context.settings)
+    val file = InputFile.fromRelativeFilename(code.filename, context.settings)
     val markdown = Markdown.toMarkdown(
       cleanInput,
       myContext,

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
@@ -10,7 +10,8 @@ public abstract class EvaluatedWorksheet {
   public abstract List<Diagnostic> diagnostics();
   public abstract List<EvaluatedWorksheetStatement> statements();
 
-  public abstract List<String> scalacOptions();
+  public abstract List<ImportedScriptFile> files();
+  public abstract List<String> scalac();
   public abstract List<Path> classpath();
   public abstract List<Dependency> dependencies();
   public abstract List<Repository> repositories();

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
@@ -1,10 +1,18 @@
 package mdoc.interfaces;
 
 import java.util.List;
+import java.nio.file.Path;
+import coursierapi.Dependency;
+import coursierapi.Repository;
 
 public abstract class EvaluatedWorksheet {
 
   public abstract List<Diagnostic> diagnostics();
   public abstract List<EvaluatedWorksheetStatement> statements();
+
+  public abstract List<String> scalacOptions();
+  public abstract List<Path> classpath();
+  public abstract List<Dependency> dependencies();
+  public abstract List<Repository> repositories();
 
 }

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/ImportedScriptFile.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/ImportedScriptFile.java
@@ -1,0 +1,15 @@
+package mdoc.interfaces;
+
+import java.util.List;
+import java.nio.file.Path;
+
+public abstract class ImportedScriptFile {
+
+  public abstract Path path();
+  public abstract String packageName();
+  public abstract String objectName();
+  public abstract String instrumentedSource();
+  public abstract String originalSource();
+  public abstract List<ImportedScriptFile> files();
+
+}

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
@@ -13,6 +13,7 @@ public abstract class Mdoc {
   public abstract Mdoc withConsoleReporter(PrintStream out);
   public abstract Mdoc withScreenHeight(int screenHeight);
   public abstract Mdoc withScreenWidth(int screenWidth);
+  public abstract Mdoc withCoursierLogger(coursierapi.Logger logger);
   public abstract void shutdown();
 
 }

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
@@ -7,6 +7,7 @@ import java.io.PrintStream;
 public abstract class Mdoc {
 
   public abstract EvaluatedWorksheet evaluateWorksheet(String filename, String text);
+  public abstract Mdoc withWorkingDirectory(Path workingDirectory);
   public abstract Mdoc withClasspath(List<Path> classpath);
   public abstract Mdoc withScalacOptions(List<String> options);
   public abstract Mdoc withSettings(List<String> settings);

--- a/mdoc-js/src/main/scala-2.12/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala-2.12/mdoc/modifiers/JsModifier.scala
@@ -137,7 +137,7 @@ class JsModifier extends mdoc.PreModifier {
     val input = Input.VirtualFile(ctx.relativePath.toString(), wrapped)
     val edit = TokenEditDistance.fromInputs(inputs, input)
     val oldErrors = ctx.reporter.errorCount
-    compiler.compileSources(input, ctx.reporter, edit)
+    compiler.compileSources(input, ctx.reporter, edit, fileImports = Nil)
     val hasErrors = ctx.reporter.errorCount > oldErrors
     val sjsir = for {
       x <- target.toList

--- a/mdoc/src/main/scala/mdoc/MainSettings.scala
+++ b/mdoc/src/main/scala/mdoc/MainSettings.scala
@@ -98,6 +98,9 @@ final class MainSettings private (
   def withVariablePrinter(variablePrinter: Variable => String): MainSettings = {
     copy(settings.copy(variablePrinter = variablePrinter))
   }
+  def withCoursierLogger(logger: coursierapi.Logger): MainSettings = {
+    copy(settings.copy(coursierLogger = logger))
+  }
   def withScreenWidth(screenWidth: Int): MainSettings = {
     copy(settings.copy(screenWidth = screenWidth))
   }

--- a/mdoc/src/main/scala/mdoc/internal/cli/Context.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Context.scala
@@ -1,14 +1,35 @@
 package mdoc.internal.cli
 
+import scala.collection.JavaConverters._
 import mdoc.Reporter
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.MarkdownCompiler
+import coursierapi.Dependency
+import scala.collection.mutable
+import scala.meta.io.Classpath
+import scala.meta.io.AbsolutePath
+import mdoc.internal.markdown.Instrumented
+import coursierapi.Logger
 
-case class Context(settings: Settings, reporter: Reporter, compiler: MarkdownCompiler)
+case class Context(
+    settings: Settings,
+    reporter: Reporter,
+    compiler: MarkdownCompiler,
+    compilers: mutable.Map[Set[Dependency], MarkdownCompiler] = mutable.Map.empty
+) {
+  def compiler(instrumented: Instrumented) =
+    compilers.getOrElseUpdate(
+      instrumented.dependencies,
+      Dependencies.newCompiler(settings, instrumented)
+    )
+}
 
 object Context {
+  def fromCompiler(options: Settings, reporter: Reporter, compiler: MarkdownCompiler): Context = {
+    new Context(options, reporter, compiler)
+  }
   def fromOptions(options: Settings, reporter: Reporter = ConsoleReporter.default): Context = {
     val compiler = MarkdownCompiler.fromClasspath(options.classpath, options.scalacOptions)
-    Context(options, reporter, compiler)
+    fromCompiler(options, reporter, compiler)
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/cli/Dependencies.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Dependencies.scala
@@ -10,6 +10,7 @@ import mdoc.internal.markdown.Instrumented
 import coursierapi.ResolutionParams
 import coursierapi.Cache
 import coursierapi.Logger
+import scala.collection.immutable.Nil
 
 object Dependencies {
   def newCompiler(
@@ -26,6 +27,12 @@ object Dependencies {
       .map(_.toPath())
     val classpath =
       Classpath(Classpath(settings.classpath).entries ++ jars.map(AbsolutePath(_)))
-    MarkdownCompiler.fromClasspath(classpath.syntax, settings.scalacOptions)
+    val scalacOptions = instrumented.scalacOptionImports match {
+      case Nil =>
+        settings.scalacOptions
+      case options =>
+        s"${settings.scalacOptions} ${options.map(_.value).mkString(" ")}"
+    }
+    MarkdownCompiler.fromClasspath(classpath.syntax, scalacOptions)
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/cli/Dependencies.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Dependencies.scala
@@ -1,0 +1,31 @@
+package mdoc.internal.cli
+
+import scala.meta.io.Classpath
+import coursierapi.Dependency
+import mdoc.internal.markdown.MarkdownCompiler
+import scala.collection.JavaConverters._
+import scala.meta.io.AbsolutePath
+import coursierapi.Repository
+import mdoc.internal.markdown.Instrumented
+import coursierapi.ResolutionParams
+import coursierapi.Cache
+import coursierapi.Logger
+
+object Dependencies {
+  def newCompiler(
+      settings: Settings,
+      instrumented: Instrumented
+  ): MarkdownCompiler = {
+    val jars = coursierapi.Fetch
+      .create()
+      .addDependencies(instrumented.dependencies.toArray: _*)
+      .addRepositories(instrumented.repositories.toArray: _*)
+      .withCache(Cache.create().withLogger(settings.coursierLogger))
+      .fetch()
+      .asScala
+      .map(_.toPath())
+    val classpath =
+      Classpath(Classpath(settings.classpath).entries ++ jars.map(AbsolutePath(_)))
+    MarkdownCompiler.fromClasspath(classpath.syntax, settings.scalacOptions)
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/cli/InputFile.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/InputFile.scala
@@ -29,10 +29,16 @@ object InputFile {
     }
   }
 
-  def fromSettings(filename: String, settings: Settings): InputFile = {
+  def fromRelativeFilename(filename: String, settings: Settings): InputFile = {
     val relpath = RelativePath(filename)
     val inputDir = settings.in.head
     val outputDir = settings.out.head
-    InputFile(relpath, inputDir.resolve(filename), outputDir.resolve(filename), inputDir, outputDir)
+    InputFile(
+      relpath,
+      inputDir.resolve(filename),
+      outputDir.resolve(filename),
+      inputDir,
+      outputDir
+    )
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -76,9 +76,7 @@ case class Settings(
     )
     classpath: String = "",
     @Description(
-      "Compiler flags such as compiler plugins '-Xplugin:kind-projector.jar' " +
-        "or custom options '-deprecated'. Formatted as a single string with space separated values. " +
-        "To pass multiple values: --scalac-options \"-Yrangepos -deprecated\". " +
+      "Space separated list of compiler flags such as '-Xplugin:kind-projector.jar -deprecation -Yrangepos'. " +
         "Defaults to the value of 'scalacOptions' in the 'mdoc.properties' resource file, if any. " +
         "When using sbt-mdoc, update the `scalacOptions` sbt setting instead of passing --scalac-options to `mdocExtraArguments`."
     )

--- a/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/ConsoleReporter.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.meta.Position
 import mdoc.Reporter
 import mdoc.internal.pos.PositionSyntax._
+import coursierapi.Logger
 
 class ConsoleReporter(
     ps: PrintStream,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -37,9 +37,9 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
                 case i: Import =>
                   i.importers.foreach {
                     case Importer(
-                        Term.Name("$ivy" | "$dep" | "$scalac"),
-                        List(Importee.Name(dep: Name.Indeterminate))
-                        ) =>
+                        Term.Name(name),
+                        List(Importee.Name(_: Name.Indeterminate))
+                        ) if Instrumenter.magicImports(name) =>
                     case importer =>
                       sb.print("import ")
                       sb.print(importer.syntax)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FailInstrumenter.scala
@@ -2,6 +2,11 @@ package mdoc.internal.markdown
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import scala.meta.Import
+import scala.meta.Importer
+import scala.meta.Term
+import scala.meta.Importee
+import scala.meta.Name
 
 final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private val out = new ByteArrayOutputStream()
@@ -27,7 +32,23 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
             nest.nest()
           }
           if (j == i || !section.mod.isFailOrWarn) {
-            sb.println(section.input.text)
+            section.source.stats.foreach { stat =>
+              stat match {
+                case i: Import =>
+                  i.importers.foreach {
+                    case Importer(
+                        Term.Name("$ivy" | "$dep" | "$scalac"),
+                        List(Importee.Name(dep: Name.Indeterminate))
+                        ) =>
+                    case importer =>
+                      sb.print("import ")
+                      sb.print(importer.syntax)
+                      sb.print(";")
+                  }
+                case _ =>
+                  sb.println(stat.pos.text)
+              }
+            }
           }
         }
     }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FileImport.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FileImport.scala
@@ -1,0 +1,129 @@
+package mdoc.internal.markdown
+
+import scala.meta.io.AbsolutePath
+import java.nio.file.Path
+import scala.meta.Name
+import scala.meta.inputs.Input
+import mdoc.internal.pos.PositionSyntax._
+import scala.meta.Importee
+import scala.meta.Term
+import mdoc.Reporter
+import scala.meta.Importer
+import mdoc.internal.cli.InputFile
+import scala.collection.mutable
+import mdoc.internal.cli.Settings
+import scala.meta.inputs.Position
+import mdoc.internal.pos.TokenEditDistance
+import scala.meta.Import
+
+final case class FileImport(
+    path: AbsolutePath,
+    qualifier: Term,
+    importName: Name.Indeterminate,
+    objectName: String,
+    packageName: String,
+    source: String,
+    dependencies: List[FileImport],
+    renames: List[Rename]
+) {
+  val fullyQualifiedName = s"$packageName.$objectName"
+  val prefix: String =
+    s"package $packageName; object $objectName {"
+  val toInput: Input = {
+    val out = new java.lang.StringBuilder().append(prefix)
+    var i = 0
+    renames.sortBy(_.from.start).foreach { rename =>
+      out
+        .append(source, i, rename.from.start)
+        .append(rename.to)
+      i = rename.from.end
+    }
+    out
+      .append(source, i, source.length())
+      .append("\n}\n")
+    Input.VirtualFile(path.syntax, out.toString())
+  }
+  val edit = TokenEditDistance(Input.VirtualFile(path.syntax, source), toInput)
+}
+object FileImport {
+  class Matcher(
+      settings: Settings,
+      file: InputFile,
+      reporter: Reporter
+  ) {
+    def unapply(importer: Importer): Option[List[FileImport]] = importer match {
+      case importer @ Importer(qual, importees) if isFileQualifier(qual) =>
+        val parsed = FileImport.fromImportees(file.inputFile, qual, importees, reporter, settings)
+        if (parsed.forall(_.isDefined)) Some(parsed.map(_.get))
+        else None
+      case _ =>
+        None
+    }
+    private def isFileQualifier(qual: Term): Boolean = qual match {
+      case Term.Name("$file") => true
+      case Term.Select(next, _) => isFileQualifier(next)
+      case _ => false
+    }
+  }
+
+  private def fromImportees(
+      base: AbsolutePath,
+      qual: Term,
+      importees: List[Importee],
+      reporter: Reporter,
+      settings: Settings
+  ): List[Option[FileImport]] = {
+    importees.collect {
+      case Importee.Name(name: Name.Indeterminate) =>
+        fromImport(base, qual, name, reporter, settings)
+      case Importee.Rename(name: Name.Indeterminate, _) =>
+        fromImport(base, qual, name, reporter, settings)
+      case i @ Importee.Wildcard() =>
+        reporter.error(
+          i.pos,
+          "wildcards are not supported for $file imports. " +
+            "To fix this problem, explicitly import files using the `import $file.FILENAME` syntax."
+        )
+        None
+      case i @ Importee.Unimport(_) =>
+        reporter.error(
+          i.pos,
+          "unimports are not supported for $file imports. " +
+            "To fix this problem, remove the unimported symbol."
+        )
+        None
+    }
+  }
+  private def fromImport(
+      base: AbsolutePath,
+      qual: Term,
+      fileImport: Name.Indeterminate,
+      reporter: Reporter,
+      settings: Settings
+  ): Option[FileImport] = {
+    def loop(path: Path, parts: List[String]): Path = parts match {
+      case Nil => path
+      case "^" :: tail =>
+        loop(path.getParent, tail)
+      case "^^" :: tail =>
+        loop(path.getParent.getParent(), tail)
+      case "^^^" :: tail =>
+        loop(path.getParent.getParent.getParent(), tail)
+      case head :: tail =>
+        loop(path.resolve(head), tail)
+    }
+    val parts = Term.Select(qual, Term.Name(fileImport.value)).syntax.split('.').toList
+    val relativePath = parts.tail
+    val packageName = parts.init.mkString(".")
+    val objectName = parts.last
+    val importedPath = loop(base.toNIO.getParent(), relativePath)
+    val scriptPath = AbsolutePath(importedPath).resolveSibling(_ + ".sc")
+    if (scriptPath.isFile) {
+      val text = scriptPath.readText
+      Some(FileImport(scriptPath, qual, fileImport, objectName, packageName, text, Nil, Nil))
+    } else {
+      reporter.error(fileImport.pos, s"no such file $scriptPath")
+      None
+    }
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/FileImport.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/FileImport.scala
@@ -15,6 +15,8 @@ import mdoc.internal.cli.Settings
 import scala.meta.inputs.Position
 import mdoc.internal.pos.TokenEditDistance
 import scala.meta.Import
+import mdoc.interfaces.ImportedScriptFile
+import scala.collection.JavaConverters._
 
 final case class FileImport(
     path: AbsolutePath,
@@ -44,6 +46,16 @@ final case class FileImport(
     Input.VirtualFile(path.syntax, out.toString())
   }
   val edit = TokenEditDistance(Input.VirtualFile(path.syntax, source), toInput)
+  def toInterface: ImportedScriptFile = {
+    mdoc.internal.worksheets.ImportedScriptFile(
+      path.toNIO,
+      packageName,
+      objectName,
+      toInput.text,
+      source,
+      dependencies.map(_.toInterface).asJava
+    )
+  }
 }
 object FileImport {
   class Matcher(

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
@@ -15,6 +15,7 @@ import coursierapi.error.CoursierError
 
 case class Instrumented(
     source: String,
+    scalacOptionImports: List[Name.Indeterminate],
     dependencyImports: List[Name.Indeterminate],
     repositoryImports: List[Name.Indeterminate],
     positionedDependencies: List[PositionedDependency],
@@ -25,6 +26,7 @@ case class Instrumented(
 object Instrumented {
   def fromSource(
       source: String,
+      scalacOptionImports: List[Name.Indeterminate],
       dependencyImports: List[Name.Indeterminate],
       repositoryImports: List[Name.Indeterminate],
       reporter: Reporter
@@ -49,6 +51,7 @@ object Instrumented {
       } yield repo
     Instrumented(
       source,
+      scalacOptionImports,
       dependencyImports,
       repositoryImports,
       positioned,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
@@ -18,6 +18,7 @@ case class Instrumented(
     scalacOptionImports: List[Name.Indeterminate],
     dependencyImports: List[Name.Indeterminate],
     repositoryImports: List[Name.Indeterminate],
+    fileImports: List[FileImport],
     positionedDependencies: List[PositionedDependency],
     dependencies: Set[Dependency],
     repositories: List[Repository]
@@ -29,6 +30,7 @@ object Instrumented {
       scalacOptionImports: List[Name.Indeterminate],
       dependencyImports: List[Name.Indeterminate],
       repositoryImports: List[Name.Indeterminate],
+      fileImports: List[FileImport],
       reporter: Reporter
   ): Instrumented = {
     val positioned = dependencyImports.flatMap(i => PositionedDependency.fromName(i, reporter))
@@ -54,6 +56,7 @@ object Instrumented {
       scalacOptionImports,
       dependencyImports,
       repositoryImports,
+      fileImports,
       positioned,
       dependencies,
       repositories

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
@@ -1,0 +1,59 @@
+package mdoc.internal.markdown
+
+import coursierapi.Dependency
+import mdoc.internal.BuildInfo
+import scala.util.matching.Regex
+import scala.meta.Name
+import scala.collection.mutable
+import coursierapi.IvyRepository
+import coursierapi.Repository
+import coursierapi.MavenRepository
+import mdoc.Reporter
+import scala.util.Failure
+import scala.util.Success
+import coursierapi.error.CoursierError
+
+case class Instrumented(
+    source: String,
+    dependencyImports: List[Name.Indeterminate],
+    repositoryImports: List[Name.Indeterminate],
+    positionedDependencies: List[PositionedDependency],
+    dependencies: Set[Dependency],
+    repositories: List[Repository]
+)
+
+object Instrumented {
+  def fromSource(
+      source: String,
+      dependencyImports: List[Name.Indeterminate],
+      repositoryImports: List[Name.Indeterminate],
+      reporter: Reporter
+  ): Instrumented = {
+    val positioned = dependencyImports.flatMap(i => PositionedDependency.fromName(i, reporter))
+    val dependencies = positioned.map(_.dep).toSet
+    val repositories =
+      for {
+        name <- repositoryImports
+        repo <- SharedRepositoryParser.repository(name.value) match {
+          case Failure(exception) =>
+            exception match {
+              case _: CoursierError =>
+                reporter.error(name.pos, exception.getMessage())
+              case _ =>
+                reporter.error(name.pos, exception)
+            }
+            Nil
+          case Success(value) =>
+            List(value)
+        }
+      } yield repo
+    Instrumented(
+      source,
+      dependencyImports,
+      repositoryImports,
+      positioned,
+      dependencies,
+      repositories
+    )
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumenter.scala
@@ -13,8 +13,15 @@ import mdoc.Reporter
 class Instrumenter(sections: List[SectionInput]) {
   def instrument(reporter: Reporter): Instrumented = {
     printAsScript()
-    Instrumented.fromSource(out.toString, dependencies.toList, repositories.toList, reporter)
+    Instrumented.fromSource(
+      out.toString,
+      scalacOptions.toList,
+      dependencies.toList,
+      repositories.toList,
+      reporter
+    )
   }
+  private val scalacOptions = mutable.ListBuffer.empty[Name.Indeterminate]
   private val dependencies = mutable.ListBuffer.empty[Name.Indeterminate]
   private val repositories = mutable.ListBuffer.empty[Name.Indeterminate]
   private val out = new ByteArrayOutputStream()
@@ -97,6 +104,11 @@ class Instrumenter(sections: List[SectionInput]) {
                 List(Importee.Name(repo: Name.Indeterminate))
                 ) =>
               repositories += repo
+            case Importer(
+                Term.Name("$scalac"),
+                List(Importee.Name(option: Name.Indeterminate))
+                ) =>
+              scalacOptions += option
             case importer =>
               sb.print("import ")
               sb.print(importer.syntax)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/IvyResolution.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/IvyResolution.scala
@@ -1,0 +1,9 @@
+package mdoc.internal.markdown
+
+import coursierapi.Dependency
+import coursierapi.Repository
+
+final case class IvyResolution(
+    dependencies: Set[Dependency],
+    repositories: Set[Repository]
+)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MagicImports.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MagicImports.scala
@@ -1,0 +1,119 @@
+package mdoc.internal.markdown
+
+import scala.collection.mutable
+import scala.meta.Name
+import scala.meta.io.AbsolutePath
+import mdoc.internal.cli.InputFile
+import mdoc.internal.cli.Settings
+import scala.meta.Importer
+import mdoc.Reporter
+import scala.meta.Importee
+import scala.meta.Term
+import scala.meta.inputs.Input
+import scala.meta.parsers.Parsed.Success
+import scala.meta.Source
+import scala.meta.Import
+import mdoc.internal.pos.PositionSyntax._
+import scala.meta.inputs.Position
+
+class MagicImports(settings: Settings, reporter: Reporter, file: InputFile) {
+
+  val scalacOptions = mutable.ListBuffer.empty[Name.Indeterminate]
+  val dependencies = mutable.ListBuffer.empty[Name.Indeterminate]
+  val repositories = mutable.ListBuffer.empty[Name.Indeterminate]
+  val files = mutable.Map.empty[AbsolutePath, FileImport]
+
+  class Printable(inputFile: InputFile, parents: List[FileImport]) {
+    private val File = new FileImport.Matcher(settings, inputFile, reporter)
+    def unapply(importer: Importer): Option[List[FileImport]] = {
+      importer match {
+        case File(fileImports) =>
+          Some(fileImports.map(i => visitFile(i, parents)))
+        case _ =>
+          None
+      }
+    }
+  }
+  object Printable extends Printable(file, Nil)
+
+  object NonPrintable {
+    def unapply(importer: Importer): Boolean = importer match {
+      case Importer(
+          Term.Name(qualifier),
+          List(Importee.Name(name: Name.Indeterminate))
+          ) if Instrumenter.magicImports(qualifier) =>
+        qualifier match {
+          case "$ivy" | "$dep" =>
+            dependencies += name
+            true
+          case "$repo" =>
+            repositories += name
+            true
+          case "$scalac" =>
+            scalacOptions += name
+            true
+          case _ =>
+            false
+        }
+      case _ => false
+    }
+  }
+
+  private def visitFile(fileImport: FileImport, parents: List[FileImport]): FileImport = {
+    if (parents.exists(_.path == fileImport.path)) {
+      val all = (parents.reverse :+ fileImport).map(_.importName.pos.toUnslicedPosition)
+      val cycle = all
+        .map(pos => s"${pos.input.filename}:${pos.startLine}")
+        .mkString(
+          s"\n -- root       --> ",
+          s"\n -- depends on --> ",
+          s"\n -- cycle      --> ${fileImport.path}"
+        )
+      reporter.error(
+        all.head,
+        s"illegal cyclic dependency. " +
+          s"To fix this problem, refactor the code so that no transitive $$file imports end " +
+          s"up depending on the original file.$cycle"
+      )
+      fileImport
+    } else {
+      files.getOrElseUpdate(fileImport.path, visitFileUncached(fileImport, parents))
+    }
+  }
+  private def visitFileUncached(fileImport: FileImport, parents: List[FileImport]): FileImport = {
+    val input = Input.VirtualFile(fileImport.path.toString(), fileImport.source)
+    val FilePrintable = new Printable(
+      InputFile.fromRelativeFilename(
+        fileImport.path.toRelative(this.file.inputFile.parent).toString(),
+        settings
+      ),
+      fileImport :: parents
+    )
+    val fileDependencies = mutable.ListBuffer.empty[FileImport]
+    val renames = mutable.ListBuffer.empty[Rename]
+    MdocDialect.scala(input).parse[Source] match {
+      case e: scala.meta.parsers.Parsed.Error =>
+        reporter.error(e.pos, e.message)
+      case Success(source) =>
+        source.stats.foreach {
+          case i: Import =>
+            i.importers.foreach {
+              case importer @ FilePrintable(deps) =>
+                deps.foreach { dep =>
+                  if (importer.ref.syntax != dep.packageName) {
+                    renames += Rename(importer.ref.pos, dep.packageName)
+                  }
+                  fileDependencies += dep
+                }
+              case NonPrintable() =>
+              case _ =>
+            }
+          case _ =>
+        }
+    }
+    fileImport.copy(
+      dependencies = fileDependencies.toList,
+      renames = renames.toList
+    )
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -28,6 +28,7 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.io.VirtualDirectory
 import sun.misc.Unsafe
+import scala.annotation.implicitNotFound
 
 object MarkdownCompiler {
 
@@ -37,14 +38,21 @@ object MarkdownCompiler {
       compiler: MarkdownCompiler,
       reporter: Reporter,
       sectionInputs: List[SectionInput],
-      instrumented: String,
+      instrumented: Instrumented,
       filename: String
   ): EvaluatedDocument = {
-    val instrumentedInput = InstrumentedInput(filename, instrumented)
+    val instrumentedInput = InstrumentedInput(filename, instrumented.source)
     reporter.debug(s"$filename: instrumented code\n$instrumented")
-    val compileInput = Input.VirtualFile(filename, instrumented)
+    val compileInput = Input.VirtualFile(filename, instrumented.source)
     val edit = TokenEditDistance.fromTrees(sectionInputs.map(_.source), compileInput)
-    val doc = compiler.compile(compileInput, reporter, edit, "repl.Session$") match {
+    val compiled = compiler.compile(
+      compileInput,
+      reporter,
+      edit,
+      "repl.Session$",
+      instrumented.fileImports
+    )
+    val doc = compiled match {
       case Some(cls) =>
         val ctor = cls.getDeclaredConstructor()
         ctor.setAccessible(true)
@@ -208,13 +216,19 @@ class MarkdownCompiler(
   def hasErrors: Boolean = sreporter.hasErrors
   def hasWarnings: Boolean = sreporter.hasWarnings
 
-  def compileSources(input: Input, vreporter: Reporter, edit: TokenEditDistance): Unit = {
+  def compileSources(
+      input: Input,
+      vreporter: Reporter,
+      edit: TokenEditDistance,
+      fileImports: List[FileImport]
+  ): Unit = {
     clearTarget()
     sreporter.reset()
     val g = global
     val run = new g.Run
-    run.compileSources(List(toSource(input)))
-    report(vreporter, input, edit)
+    val inputs = input :: fileImports.map(_.toInput)
+    run.compileSources(inputs.map(toSource))
+    report(vreporter, input, edit, fileImports)
   }
 
   def compile(
@@ -222,10 +236,11 @@ class MarkdownCompiler(
       vreporter: Reporter,
       edit: TokenEditDistance,
       className: String,
+      fileImports: List[FileImport],
       retry: Int = 0
   ): Option[Class[_]] = {
     reset()
-    compileSources(input, vreporter, edit)
+    compileSources(input, vreporter, edit, fileImports)
     if (!sreporter.hasErrors) {
       val loader = new AbstractFileClassLoader(target, appClassLoader)
       try {
@@ -234,7 +249,7 @@ class MarkdownCompiler(
         case _: ClassNotFoundException =>
           if (retry < 1) {
             reset()
-            compile(input, vreporter, edit, className, retry + 1)
+            compile(input, vreporter, edit, className, fileImports, retry + 1)
           } else {
             vreporter.error(
               s"${input.syntax}: skipping file, the compiler produced no classfiles " +
@@ -276,34 +291,61 @@ class MarkdownCompiler(
 
   private def nullableMessage(msgOrNull: String): String =
     if (msgOrNull == null) "" else msgOrNull
-  private def report(vreporter: Reporter, input: Input, edit: TokenEditDistance): Unit = {
-    sreporter.infos.foreach {
+  private def report(
+      vreporter: Reporter,
+      input: Input,
+      edit: TokenEditDistance,
+      fileImports: List[FileImport]
+  ): Unit = {
+    val infos = sreporter.infos.toSeq.sortBy(_.pos.source.path)
+    infos.foreach {
       case sreporter.Info(pos, msgOrNull, severity) =>
         val msg = nullableMessage(msgOrNull)
-        val mpos = toMetaPosition(edit, pos)
+        val actualEdit =
+          if (pos.source.file.name.endsWith(".sc")) {
+            fileImports
+              .collectFirst {
+                case fileImport if fileImport.path.toNIO.endsWith(pos.source.file.name) =>
+                  fileImport.edit
+              }
+              .flatten
+              .getOrElse(edit)
+          } else {
+            edit
+          }
+        val mpos = toMetaPosition(actualEdit, pos)
         val actualMessage =
           if (mpos == Position.None) {
             val line = pos.lineContent
             if (line.nonEmpty) {
-              new CodeBuilder()
-                .println(s"${input.syntax}:${pos.line} (mdoc generated code) $msg")
-                .println(pos.lineContent)
-                .println(pos.lineCaret)
-                .toString
+              formatMessage(pos, msg)
             } else {
               msg
             }
           } else {
             msg
           }
-        severity match {
-          case sreporter.ERROR => vreporter.error(mpos, actualMessage)
-          case sreporter.INFO => vreporter.info(mpos, actualMessage)
-          case sreporter.WARNING => vreporter.warning(mpos, actualMessage)
-          case _ =>
-        }
+        reportMessage(vreporter, severity, mpos, actualMessage)
       case _ =>
     }
   }
+
+  private def reportMessage(
+      vreporter: Reporter,
+      severity: sreporter.Severity,
+      mpos: Position,
+      message: String
+  ): Unit = severity match {
+    case sreporter.ERROR => vreporter.error(mpos, message)
+    case sreporter.INFO => vreporter.info(mpos, message)
+    case sreporter.WARNING => vreporter.warning(mpos, message)
+    case _ =>
+  }
+  private def formatMessage(pos: GPosition, message: String): String =
+    new CodeBuilder()
+      .println(s"${pos.source.file.path}:${pos.line + 1} (mdoc generated code) $message")
+      .println(pos.lineContent)
+      .println(pos.lineCaret)
+      .toString
 
 }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -144,7 +144,7 @@ object MarkdownCompiler {
 
 class MarkdownCompiler(
     classpath: String,
-    scalacOptions: String,
+    val scalacOptions: String,
     target: AbstractFile = new VirtualDirectory("(memory)", None)
 ) {
   private val settings = new Settings()
@@ -158,6 +158,8 @@ class MarkdownCompiler(
   //   https://github.com/scalameta/mdoc/issues/124
   settings.Ydelambdafy.value = "inline"
   settings.processArgumentString(scalacOptions)
+
+  def classpathEntries: Seq[Path] = global.classPath.asURLs.map(url => Paths.get(url.toURI()))
 
   private val sreporter = new FilterStoreReporter(settings)
   var global = new Global(settings, sreporter)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -298,6 +298,7 @@ class MarkdownCompiler(
           case sreporter.ERROR => vreporter.error(mpos, actualMessage)
           case sreporter.INFO => vreporter.info(mpos, actualMessage)
           case sreporter.WARNING => vreporter.warning(mpos, actualMessage)
+          case _ =>
         }
       case _ =>
     }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/PositionedDependency.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/PositionedDependency.scala
@@ -1,0 +1,41 @@
+package mdoc.internal.markdown
+
+import scala.meta.inputs.Position
+import coursierapi.Dependency
+import scala.meta.Name
+import scala.util.matching.Regex
+import mdoc.internal.BuildInfo
+import mdoc.Reporter
+
+final case class PositionedDependency(pos: Position, dep: Dependency) {
+  def syntax: String =
+    s"${dep.getModule().getOrganization()}:${dep.getModule().getName()}:${dep.getVersion()}"
+}
+
+object PositionedDependency {
+  val Full: Regex = "(.+):::(.+):(.+)".r
+  val Half: Regex = "(.+)::(.+):(.+)".r
+  val Java: Regex = "(.+):(.+):(.+)".r
+  def fromName(i: Name.Indeterminate, reporter: Reporter): Option[PositionedDependency] = {
+    def create(
+        org: String,
+        artifact: String,
+        version: String
+    ): Option[PositionedDependency] =
+      Some(PositionedDependency(i.pos, Dependency.of(org, artifact, version)))
+    i.value match {
+      case Full(org, name, version) =>
+        create(org, s"${name}_${BuildInfo.scalaVersion}", version)
+      case Half(org, name, version) =>
+        create(org, s"${name}_${BuildInfo.scalaBinaryVersion}", version)
+      case Java(org, name, version) =>
+        create(org, name, version)
+      case _ =>
+        reporter.error(
+          i.pos,
+          "invalid dependency. To fix this error, use the format `$ORGANIZATION:$ARTIFACT:$NAME`."
+        )
+        None
+    }
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
@@ -185,7 +185,7 @@ class Processor(implicit ctx: Context) {
           section,
           ctx.reporter,
           ctx.settings.variablePrinter,
-          ctx.compiler
+          markdownCompiler
         )
         mod match {
           case Modifier.Post(modifier, info) =>

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Rename.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Rename.scala
@@ -1,0 +1,5 @@
+package mdoc.internal.markdown
+
+import scala.meta.inputs.Position
+
+final case class Rename(from: Position, to: String)

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -26,9 +26,9 @@ object Renderer {
   ): String = {
     val inputs =
       sections.map(s => SectionInput(s, MdocDialect.scala(s).parse[Source].get, Modifier.Default()))
-    val instrumented = Instrumenter.instrument(inputs)
+    val instrumented = Instrumenter.instrument(inputs, reporter)
     val doc =
-      MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented, filename)
+      MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented.source, filename)
     doc.sections
       .map(s => s"""```scala
                    |${Renderer.renderEvaluatedSection(doc, s, reporter, printer, compiler)}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -14,21 +14,31 @@ import mdoc.internal.pos.PositionSyntax._
 import mdoc.internal.pos.TokenEditDistance
 import scala.meta._
 import scala.meta.inputs.Position
+import mdoc.internal.cli.InputFile
+import mdoc.internal.cli.Settings
 
 object Renderer {
 
   def render(
+      file: InputFile,
       sections: List[Input],
       compiler: MarkdownCompiler,
+      settings: Settings,
       reporter: Reporter,
       filename: String,
       printer: Variable => String
   ): String = {
     val inputs =
       sections.map(s => SectionInput(s, MdocDialect.scala(s).parse[Source].get, Modifier.Default()))
-    val instrumented = Instrumenter.instrument(inputs, reporter)
+    val instrumented = Instrumenter.instrument(file, inputs, settings, reporter)
     val doc =
-      MarkdownCompiler.buildDocument(compiler, reporter, inputs, instrumented.source, filename)
+      MarkdownCompiler.buildDocument(
+        compiler,
+        reporter,
+        inputs,
+        instrumented,
+        filename
+      )
     doc.sections
       .map(s => s"""```scala
                    |${Renderer.renderEvaluatedSection(doc, s, reporter, printer, compiler)}

--- a/mdoc/src/main/scala/mdoc/internal/markdown/SharedRepositoryParser.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/SharedRepositoryParser.scala
@@ -1,0 +1,72 @@
+/**
+  * This file is derived from the following Coursier sources, see NOTICE for license details.
+  * https://github.com/coursier/coursier/blob/dfb04cab48a4beefa2be59fc71e3eff0493a5886/modules/coursier/shared/src/main/scala/coursier/Repositories.scala
+  * https://github.com/coursier/coursier/blob/dfb04cab48a4beefa2be59fc71e3eff0493a5886/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
+  */
+package mdoc.internal.markdown
+
+import scala.util.Try
+import coursierapi.Repository
+import coursierapi.IvyRepository
+import coursierapi.MavenRepository
+import coursierapi.error.CoursierError
+
+object SharedRepositoryParser {
+
+  def repository(s: String): Try[Repository] = Try {
+    if (s == "central") {
+      Repository.central()
+    } else if (s.startsWith("sonatype:")) {
+      Repositories.sonatype(s.stripPrefix("sonatype:"))
+    } else if (s.startsWith("bintray:")) {
+      val s0 = s.stripPrefix("bintray:")
+      val id =
+        if (s.contains("/")) s0
+        else s0 + "/maven"
+      Repositories.bintray(id)
+    } else if (s.startsWith("bintray-ivy:")) {
+      unsupportedIvy("bintray-ivy")
+    } else if (s.startsWith("typesafe:ivy-")) {
+      unsupportedIvy("typesafe:ivy-")
+    } else if (s.startsWith("typesafe:")) {
+      Repositories.typesafe(s.stripPrefix("typesafe:"))
+    } else if (s.startsWith("sbt-maven:")) {
+      Repositories.sbtMaven(s.stripPrefix("sbt-maven:"))
+    } else if (s.startsWith("sbt-plugin:")) {
+      unsupportedIvy("sbt-plugin")
+    } else if (s.startsWith("ivy:")) {
+      val s0 = s.stripPrefix("ivy:")
+      val sepIdx = s0.indexOf('|')
+      if (sepIdx < 0) IvyRepository.of(s0)
+      else {
+        val mainPart = s0.substring(0, sepIdx)
+        val metadataPart = s0.substring(sepIdx + 1)
+        IvyRepository.of(mainPart, metadataPart)
+      }
+    } else if (s == "jitpack") {
+      Repositories.jitpack
+    } else {
+      MavenRepository.of(s)
+    }
+  }
+
+  private def unsupportedIvy(what: String) =
+    throw CoursierError.of(
+      s"$what repositories are not supported. Please open a feature request to discuss adding support for $what repositories https://github.com/scalameta/mdoc/"
+    )
+
+  private object Repositories {
+    def sonatype(name: String): MavenRepository =
+      MavenRepository.of(s"https://oss.sonatype.org/content/repositories/$name")
+    def bintray(id: String): MavenRepository =
+      MavenRepository.of("https://dl.bintray.com/$id")
+    def bintray(owner: String, repo: String): MavenRepository =
+      bintray(s"$owner/$repo")
+    def typesafe(id: String): MavenRepository =
+      MavenRepository.of(s"https://repo.typesafe.com/typesafe/$id")
+    def sbtMaven(id: String): MavenRepository =
+      MavenRepository.of(s"https://repo.scala-sbt.org/scalasbt/maven-$id")
+    def jitpack: MavenRepository =
+      MavenRepository.of("https://jitpack.io")
+  }
+}

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -14,6 +14,7 @@ import mdoc.internal.markdown.EvaluatedSection
 import scala.meta.internal.io.PathIO
 import scala.util.control.NonFatal
 import coursierapi.Dependency
+import scala.meta.internal.io.FileIO
 
 object PositionSyntax {
   implicit class XtensionInputMdoc(input: Input) {
@@ -185,6 +186,7 @@ object PositionSyntax {
   implicit class XtensionAbsolutePathLink(path: AbsolutePath) {
     def filename: String = path.toNIO.getFileName.toString
     def extension: String = PathIO.extension(path.toNIO)
+    def readText: String = FileIO.slurp(path, StandardCharsets.UTF_8)
     def copyTo(out: AbsolutePath): Unit = {
       Files.createDirectories(path.toNIO.getParent)
       Files.copy(path.toNIO, out.toNIO, StandardCopyOption.REPLACE_EXISTING)

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -13,6 +13,7 @@ import mdoc.internal.cli.Settings
 import mdoc.internal.markdown.EvaluatedSection
 import scala.meta.internal.io.PathIO
 import scala.util.control.NonFatal
+import coursierapi.Dependency
 
 object PositionSyntax {
   implicit class XtensionInputMdoc(input: Input) {

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
@@ -7,7 +7,8 @@ import java.nio.file.Path
 case class EvaluatedWorksheet(
     val diagnostics: ju.List[i.Diagnostic],
     val statements: ju.List[i.EvaluatedWorksheetStatement],
-    val scalacOptions: ju.List[String],
+    val files: ju.List[i.ImportedScriptFile],
+    val scalac: ju.List[String],
     val classpath: ju.List[Path],
     val dependencies: ju.List[coursierapi.Dependency],
     val repositories: ju.List[coursierapi.Repository]

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
@@ -2,8 +2,13 @@ package mdoc.internal.worksheets
 
 import java.{util => ju}
 import mdoc.{interfaces => i}
+import java.nio.file.Path
 
 case class EvaluatedWorksheet(
     val diagnostics: ju.List[i.Diagnostic],
-    val statements: ju.List[i.EvaluatedWorksheetStatement]
+    val statements: ju.List[i.EvaluatedWorksheetStatement],
+    val scalacOptions: ju.List[String],
+    val classpath: ju.List[Path],
+    val dependencies: ju.List[coursierapi.Dependency],
+    val repositories: ju.List[coursierapi.Repository]
 ) extends mdoc.interfaces.EvaluatedWorksheet

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/ImportedScriptFile.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/ImportedScriptFile.scala
@@ -1,0 +1,14 @@
+package mdoc.internal.worksheets
+
+import java.{util => ju}
+import mdoc.{interfaces => i}
+import java.nio.file.Path
+
+final case class ImportedScriptFile(
+    val path: Path,
+    val packageName: String,
+    val objectName: String,
+    val instrumentedSource: String,
+    val originalSource: String,
+    val files: ju.List[i.ImportedScriptFile]
+) extends i.ImportedScriptFile

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/Mdoc.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/Mdoc.scala
@@ -14,6 +14,7 @@ import mdoc.internal.markdown.MarkdownCompiler
 import scala.meta.inputs.Input
 import mdoc.internal.worksheets.Compat._
 import mdoc.MainSettings
+import coursierapi.Logger
 
 class Mdoc(settings: MainSettings) extends i.Mdoc {
 
@@ -33,6 +34,8 @@ class Mdoc(settings: MainSettings) extends i.Mdoc {
     new Mdoc(this.settings.withScreenWidth(screenWidth))
   def withScreenHeight(screenHeight: Int): i.Mdoc =
     new Mdoc(this.settings.withScreenHeight(screenHeight))
+  def withCoursierLogger(logger: Logger): mdoc.interfaces.Mdoc =
+    new Mdoc(this.settings.withCoursierLogger(logger))
 
   def shutdown(): Unit = {
     if (myContext != null) {
@@ -49,14 +52,7 @@ class Mdoc(settings: MainSettings) extends i.Mdoc {
 
   private def context(): Context = {
     if (myContext == null) {
-      myContext = Context(
-        settings.settings,
-        settings.reporter,
-        MarkdownCompiler.fromClasspath(
-          settings.settings.classpath,
-          settings.settings.scalacOptions
-        )
-      )
+      myContext = Context.fromOptions(settings.settings, settings.reporter)
     }
     myContext
   }

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/Mdoc.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/Mdoc.scala
@@ -22,6 +22,8 @@ class Mdoc(settings: MainSettings) extends i.Mdoc {
 
   def this() = this(MainSettings())
 
+  def withWorkingDirectory(cwd: Path): i.Mdoc =
+    new Mdoc(this.settings.withWorkingDirectory(cwd))
   def withClasspath(classpath: ju.List[Path]): i.Mdoc =
     new Mdoc(this.settings.withClasspath(classpath.iterator().asScala.mkString(File.pathSeparator)))
   def withScalacOptions(options: ju.List[String]): i.Mdoc =

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -35,12 +35,12 @@ class WorksheetProvider(settings: Settings) {
       Modifier.Default()
     )
     val sectionInputs = List(sectionInput)
-    val instrumented = Instrumenter.instrument(sectionInputs)
+    val instrumented = Instrumenter.instrument(sectionInputs, reporter)
     val rendered = MarkdownCompiler.buildDocument(
       ctx.compiler,
       reporter,
       sectionInputs,
-      instrumented,
+      instrumented.source,
       input.path
     )
 

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -55,6 +55,7 @@ class WorksheetProvider(settings: Settings) {
         .map(d => d: i.EvaluatedWorksheetStatement)
         .toList
         .asJava,
+      instrumented.fileImports.map(_.toInterface).asJava,
       instrumented.scalacOptionImports.map(_.value).asJava,
       compiler.classpathEntries.asJava,
       instrumented.dependencies.toSeq.asJava,

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -16,6 +16,7 @@ import mdoc.internal.io.StoreReporter
 import mdoc.{interfaces => i}
 import mdoc.internal.markdown.MdocDialect
 import java.{util => ju}
+import mdoc.internal.cli.InputFile
 
 class WorksheetProvider(settings: Settings) {
 
@@ -36,15 +37,11 @@ class WorksheetProvider(settings: Settings) {
       Modifier.Default()
     )
     val sectionInputs = List(sectionInput)
-    val instrumented = Instrumenter.instrument(sectionInputs, reporter)
+    val file = InputFile.fromRelativeFilename(input.path, settings)
+    val instrumented = Instrumenter.instrument(file, sectionInputs, settings, reporter)
     val compiler = ctx.compiler(instrumented)
-    val rendered = MarkdownCompiler.buildDocument(
-      compiler,
-      reporter,
-      sectionInputs,
-      instrumented.source,
-      input.path
-    )
+    val rendered =
+      MarkdownCompiler.buildDocument(compiler, reporter, sectionInputs, instrumented, input.path)
 
     val decorations = for {
       section <- rendered.sections.iterator

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -15,6 +15,7 @@ import pprint.PPrinter.BlackWhite
 import mdoc.internal.io.StoreReporter
 import mdoc.{interfaces => i}
 import mdoc.internal.markdown.MdocDialect
+import java.{util => ju}
 
 class WorksheetProvider(settings: Settings) {
 
@@ -36,8 +37,9 @@ class WorksheetProvider(settings: Settings) {
     )
     val sectionInputs = List(sectionInput)
     val instrumented = Instrumenter.instrument(sectionInputs, reporter)
+    val compiler = ctx.compiler(instrumented)
     val rendered = MarkdownCompiler.buildDocument(
-      ctx.compiler,
+      compiler,
       reporter,
       sectionInputs,
       instrumented.source,
@@ -55,7 +57,11 @@ class WorksheetProvider(settings: Settings) {
         .filterNot(_.summary.isEmpty)
         .map(d => d: i.EvaluatedWorksheetStatement)
         .toList
-        .asJava
+        .asJava,
+      instrumented.scalacOptionImports.map(_.value).asJava,
+      compiler.classpathEntries.asJava,
+      instrumented.dependencies.toSeq.asJava,
+      instrumented.repositories.toSeq.asJava
     )
   }
 

--- a/tests/unit/src/test/scala-2.12/tests/js/JsSuite.scala
+++ b/tests/unit/src/test/scala-2.12/tests/js/JsSuite.scala
@@ -236,7 +236,7 @@ class JsSuite extends BaseMarkdownSuite {
       |println(jsdocs.ExampleJS.greeting)
       |```
     """.stripMargin,
-    """|error: no-dom.md:3 (mdoc generated code) object scalajs is not a member of package org
+    """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
        |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
        |                          ^
     """.stripMargin,

--- a/tests/unit/src/test/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseSuite.scala
@@ -1,0 +1,14 @@
+package tests
+
+import munit.FunSuite
+
+class BaseSuite extends FunSuite {
+  object OnlyScala213 extends munit.Tag("OnlyScala213")
+  override def munitTestTransforms: List[TestTransform] = super.munitTestTransforms ++ List(
+    new TestTransform(OnlyScala213.value, { test =>
+      if (test.tags(OnlyScala213) && mdoc.internal.BuildInfo.scalaBinaryVersion != "2.13")
+        test.tag(munit.Ignore)
+      else test
+    })
+  )
+}

--- a/tests/unit/src/test/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseSuite.scala
@@ -1,8 +1,22 @@
 package tests
 
 import munit.FunSuite
+import munit.Location
+import tests.markdown.Compat
+import breeze.numerics.exp
 
 class BaseSuite extends FunSuite {
+  def postProcessObtained: Map[String, String => String] = Map.empty
+  def postProcessExpected: Map[String, String => String] = Map.empty
+  override def assertNoDiff(obtained: String, expected: String, clue: => Any)(
+      implicit loc: Location
+  ): Unit = {
+    super.assertNoDiff(
+      Compat(obtained, Map.empty, postProcessObtained),
+      Compat(expected, Map.empty, postProcessExpected),
+      clue
+    )
+  }
   object OnlyScala213 extends munit.Tag("OnlyScala213")
   override def munitTestTransforms: List[TestTransform] = super.munitTestTransforms ++ List(
     new TestTransform(OnlyScala213.value, { test =>

--- a/tests/unit/src/test/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseSuite.scala
@@ -3,7 +3,6 @@ package tests
 import munit.FunSuite
 import munit.Location
 import tests.markdown.Compat
-import breeze.numerics.exp
 
 class BaseSuite extends FunSuite {
   def postProcessObtained: Map[String, String => String] = Map.empty

--- a/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
@@ -10,8 +10,11 @@ import scala.meta.testkit.StringFS
 import mdoc.Main
 import scala.meta.internal.io.PathIO
 import scala.meta.io.RelativePath
+import munit.TestOptions
+import mdoc.internal.BuildInfo
+import tests.BaseSuite
 
-abstract class BaseCliSuite extends FunSuite {
+abstract class BaseCliSuite extends BaseSuite {
   class TemporaryDirectory(name: String) extends Fixture[AbsolutePath](name) {
     var path: AbsolutePath = _
     def apply(): AbsolutePath = path
@@ -24,7 +27,7 @@ abstract class BaseCliSuite extends FunSuite {
   override def munitFixtures: Seq[Fixture[_]] = List(in, out)
   private val myStdout = new ByteArrayOutputStream()
   def checkCli(
-      name: String,
+      name: TestOptions,
       original: String,
       expected: String,
       extraArgs: => Array[String] = Array.empty,

--- a/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
@@ -24,6 +24,16 @@ abstract class BaseCliSuite extends BaseSuite {
   }
   val in = new TemporaryDirectory("in")
   val out = new TemporaryDirectory("out")
+  override def postProcessObtained: Map[String, String => String] = Map(
+    "all" -> { old =>
+      old
+        .replace(out().toString(), "<output>")
+        .replace(in().toString(), "<input>")
+        .linesIterator
+        .filterNot(line => line.startsWith("info: Compiled in"))
+        .mkString("\n")
+    }
+  )
   override def munitFixtures: Seq[Fixture[_]] = List(in, out)
   private val myStdout = new ByteArrayOutputStream()
   def checkCli(

--- a/tests/unit/src/test/scala/tests/imports/DependencySuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/DependencySuite.scala
@@ -1,4 +1,6 @@
-package tests.markdown
+package tests.imports
+
+import tests.markdown.BaseMarkdownSuite
 
 class DependencySuite extends BaseMarkdownSuite {
   val userHome = System.getProperty("user.home")
@@ -13,11 +15,10 @@ class DependencySuite extends BaseMarkdownSuite {
         .mkString("\n")
     }
   )
-  override def munitIgnore: Boolean = mdoc.internal.BuildInfo.scalaBinaryVersion != "2.12"
 
   List("dep", "ivy").foreach { dep =>
     check(
-      dep,
+      dep.tag(OnlyScala213),
       s"""
          |```scala mdoc
          |import $$$dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._
@@ -36,7 +37,7 @@ class DependencySuite extends BaseMarkdownSuite {
   }
 
   check(
-    "repo",
+    "repo".tag(OnlyScala213),
     """
       |```scala mdoc
       |import $repo.`https://conjars.org/repo/`
@@ -54,7 +55,7 @@ class DependencySuite extends BaseMarkdownSuite {
   )
 
   checkError(
-    "repo-error",
+    "repo-error".tag(OnlyScala213),
     """
       |```scala mdoc
       |import $repo.`sbt-plugin:foobar`
@@ -68,7 +69,7 @@ class DependencySuite extends BaseMarkdownSuite {
   )
 
   checkError(
-    "dep-error",
+    "dep-error".tag(OnlyScala213),
     """
       |```scala mdoc
       |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
@@ -82,20 +83,21 @@ class DependencySuite extends BaseMarkdownSuite {
        |  not found: https://repo1.maven.org/maven2/org/scalameta/foobar/1.2.1/foobar-1.2.1.pom
        |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
        |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-       |error: dep-error.md:4:13: Error downloading org.scalameta:not-exists_2.12.11:2.3.4
+       |error: dep-error.md:4:13: Error downloading org.scalameta:not-exists_2.13.2:2.3.4
        |<redacted user.home>
-       |  not found: https://repo1.maven.org/maven2/org/scalameta/not-exists_2.12.11/2.3.4/not-exists_2.12.11-2.3.4.pom
+       |  not found: https://repo1.maven.org/maven2/org/scalameta/not-exists_2.13.2/2.3.4/not-exists_2.13.2-2.3.4.pom
        |import $dep.`org.scalameta:::not-exists:2.3.4`
        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-       |error: dep-error.md:3:13: Error downloading org.scalameta:mmunit_2.12:2.3.4
+       |error: dep-error.md:3:13: Error downloading org.scalameta:mmunit_2.13:2.3.4
        |<redacted user.home>
-       |  not found: https://repo1.maven.org/maven2/org/scalameta/mmunit_2.12/2.3.4/mmunit_2.12-2.3.4.pom
+       |  not found: https://repo1.maven.org/maven2/org/scalameta/mmunit_2.13/2.3.4/mmunit_2.13-2.3.4.pom
        |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin
   )
+
   checkError(
-    "dep-syntax-error",
+    "dep-syntax-error".tag(OnlyScala213),
     """
       |```scala mdoc
       |import $dep.`org.scalameta:no-version`

--- a/tests/unit/src/test/scala/tests/imports/FileSuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/FileSuite.scala
@@ -1,0 +1,333 @@
+package tests.imports
+
+import tests.markdown.BaseMarkdownSuite
+import tests.cli.BaseCliSuite
+import scala.meta.io.RelativePath
+
+class FileSuite extends BaseCliSuite {
+
+  val includeOutputPath: RelativePath => Boolean = { path => path.toNIO.endsWith("readme.md") }
+  checkCli(
+    "basic",
+    """
+      |/hello.sc
+      |val message = "Hello world!"
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello
+      |println(hello.message)
+      |```
+      |""".stripMargin,
+    """
+      |/readme.md
+      |```scala
+      |import $file.hello
+      |println(hello.message)
+      |// Hello world!
+      |```
+      |""".stripMargin,
+    includeOutputPath = includeOutputPath
+  )
+
+  checkCli(
+    "outer",
+    """
+      |/inner/hello.sc
+      |val message = "hello world"
+      |/readme.md
+      |```scala mdoc
+      |import $file.inner.hello
+      |println(hello.message)
+      |```
+      |""".stripMargin,
+    """
+      |/readme.md
+      |```scala
+      |import $file.inner.hello
+      |println(hello.message)
+      |// hello world
+      |```
+      |""".stripMargin,
+    includeOutputPath = includeOutputPath
+  )
+
+  1.to(3).foreach { i =>
+    val caret = "^" * i
+    val inner = 1.to(i).map(_ => "inner").mkString("/")
+    checkCli(
+      inner,
+      s"""
+         |/hello.sc
+         |val message = "hello world"
+         |/$inner/readme.md
+         |```scala mdoc
+         |import $$file.$caret.hello
+         |println(hello.message)
+         |```
+         |""".stripMargin,
+      s"""|/$inner/readme.md
+          |```scala
+          |import $$file.$caret.hello
+          |println(hello.message)
+          |// hello world
+          |```
+          |""".stripMargin,
+      includeOutputPath = includeOutputPath
+    )
+  }
+
+  checkCli(
+    "nested",
+    """
+      |/hello1.sc
+      |val first = "hello"
+      |val second = "world"
+      |/hello2.sc
+      |import $file.hello1
+      |val first = hello1.first
+      |/hello3.sc
+      |import $file.hello1
+      |val second = hello1.second
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello2, $file.hello3
+      |println(s"${hello2.first} ${hello3.second}")
+      |```
+      |""".stripMargin,
+    """|/readme.md
+       |```scala
+       |import $file.hello2, $file.hello3
+       |println(s"${hello2.first} ${hello3.second}")
+       |// hello world
+       |```
+       |""".stripMargin,
+    includeOutputPath = includeOutputPath
+  )
+
+  checkCli(
+    "cycles",
+    """
+      |/hello1.sc
+      |import $file.hello2
+      |val first = hello2.first
+      |/hello2.sc
+      |import $file.hello1
+      |val first = hello1.first
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello1
+      |println(s"${hello1.first} world")
+      |```
+      |""".stripMargin,
+    "",
+    expectedExitCode = 1,
+    includeOutputPath = includeOutputPath,
+    onStdout = { stdout =>
+      assertNoDiff(
+        stdout,
+        """|info: Compiling 3 files to <output>
+           |error: <input>/readme.md:2:14: illegal cyclic dependency. To fix this problem, refactor the code so that no transitive $file imports end up depending on the original file.
+           | -- root       --> <input>/readme.md:1
+           | -- depends on --> <input>/hello1.sc:0
+           | -- depends on --> <input>/hello2.sc:0
+           | -- cycle      --> <input>/hello1.sc
+           |import $file.hello1
+           |             ^^^^^^
+           |""".stripMargin
+      )
+    }
+  )
+
+  checkCli(
+    "compile-error",
+    """
+      |/hello1.sc
+      |val message: String = 42
+      |/hello2.sc
+      |import $file.hello1
+      |val number: Int = ""
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello2
+      |val something: Int = ""
+      |println(hello2.number)
+      |```
+      |""".stripMargin,
+    "",
+    expectedExitCode = 1,
+    includeOutputPath = includeOutputPath,
+    onStdout = { stdout =>
+      assertNoDiff(
+        stdout,
+        """|info: Compiling 3 files to <output>
+           |error: <input>/hello1.sc:1:23: type mismatch;
+           | found   : Int(42)
+           | required: String
+           |val message: String = 42
+           |                      ^^
+           |error: <input>/hello2.sc:2:19: type mismatch;
+           | found   : String("")
+           | required: Int
+           |val number: Int = ""
+           |                  ^^
+           |error: <input>/readme.md:3:22: type mismatch;
+           | found   : String("")
+           | required: Int
+           |val something: Int = ""
+           |                     ^^
+           |""".stripMargin
+      )
+    }
+  )
+
+  checkCli(
+    "conflicting-package",
+    """
+      |/hello0.sc
+      |val zero = 0
+      |/inner/hello1.sc
+      |val one = 1
+      |/inner/hello2.sc
+      |import $file.hello1
+      |import $file.^.hello0
+      |val two = hello1.one + 1 + hello0.zero
+      |/hello3.sc
+      |import $file.hello0
+      |import $file.inner.hello1
+      |import $file.inner.hello2
+      |val three = hello0.zero + hello1.one + hello2.two
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello3
+      |println(hello3.three)
+      |```
+      |""".stripMargin,
+    """|/readme.md
+       |```scala
+       |import $file.hello3
+       |println(hello3.three)
+       |// 3
+       |```
+       |""".stripMargin,
+    includeOutputPath = includeOutputPath
+  )
+
+  checkCli(
+    "importees",
+    """
+      |/hello0.sc
+      |val zero = 0
+      |/hello1.sc
+      |val one = 1
+      |/inner/hello2.sc
+      |import $file.^.{ hello1 => h1 }
+      |val two = h1.one + 1
+      |/readme.md
+      |```scala mdoc
+      |import $file.{ hello0, hello1 => h1 }, $file.inner.hello2
+      |println(hello0.zero)
+      |println(h1.one)
+      |println(hello2.two)
+      |```
+      |""".stripMargin,
+    """|/readme.md
+       |```scala
+       |import $file.{ hello0, hello1 => h1 }, $file.inner.hello2
+       |println(hello0.zero)
+       |// 0
+       |println(h1.one)
+       |// 1
+       |println(hello2.two)
+       |// 2
+       |```
+       |""".stripMargin,
+    includeOutputPath = includeOutputPath
+  )
+
+  checkCli(
+    "importee-unimport",
+    """
+      |/hello0.sc
+      |val zero = 0
+      |/readme.md
+      |```scala mdoc
+      |import $file.{ hello0 => _ }
+      |println("Hello world!")
+      |```
+      |""".stripMargin,
+    "",
+    expectedExitCode = 1,
+    includeOutputPath = includeOutputPath,
+    onStdout = { stdout =>
+      assertNoDiff(
+        stdout,
+        """|info: Compiling 2 files to <output>
+           |error: <input>/readme.md:2:16: unimports are not supported for $file imports. To fix this problem, remove the unimported symbol.
+           |import $file.{ hello0 => _ }
+           |               ^^^^^^^^^^^
+           |""".stripMargin
+      )
+    }
+  )
+
+  checkCli(
+    "importee-wildcard",
+    """
+      |/hello0.sc
+      |val zero = 0
+      |/readme.md
+      |```scala mdoc
+      |import $file._
+      |println(hello0.zero)
+      |```
+      |""".stripMargin,
+    "",
+    expectedExitCode = 1,
+    includeOutputPath = includeOutputPath,
+    onStdout = { stdout =>
+      assertNoDiff(
+        stdout,
+        """|info: Compiling 2 files to <output>
+           |error: <input>/readme.md:2:14: wildcards are not supported for $file imports. To fix this problem, explicitly import files using the `import $file.FILENAME` syntax.
+           |import $file._
+           |             ^
+           |""".stripMargin
+      )
+    }
+  )
+
+  checkCli(
+    "rename-edit-distance",
+    """
+      |/hello0.sc
+      |val zero = 0
+      |/inner/hello1.sc
+      |import $file.^.hello0
+      |val one = hello0.number + 1
+      |/readme.md
+      |```scala mdoc
+      |import $file.hello0, $file.inner.hello1
+      |println(hello0.zero)
+      |println(hello1.one)
+      |```
+      |""".stripMargin,
+    "",
+    expectedExitCode = 1,
+    includeOutputPath = includeOutputPath,
+    onStdout = { stdout =>
+      // NOTE(olafur): this test stresses that the caret position of the error
+      // message points to `hello0.number` despite using package renames in the
+      // import qualifier. This works because we employ token edit distance to
+      // map positions from the instrumented source to the original source.
+      assertNoDiff(
+        stdout,
+        """|info: Compiling 3 files to <output>
+           |error: <input>/inner/hello1.sc:2:11: value number is not a member of object $file.hello0
+           |val one = hello0.number + 1
+           |          ^^^^^^^^^^^^^
+           |""".stripMargin
+      )
+    }
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
@@ -1,0 +1,62 @@
+package tests.imports
+
+import tests.markdown.BaseMarkdownSuite
+
+class ScalacSuite extends BaseMarkdownSuite {
+
+  checkError(
+    "import".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |import $scalac.`-Wunused:imports -Xfatal-warnings`
+      |import scala.util.Try
+      |println(42)
+      |```
+      |""".stripMargin,
+    """|warning: import.md:4:1: Unused import
+       |import scala.util.Try
+       |^^^^^^^^^^^^^^^^^^^^^
+       |error: No warnings can be incurred under -Werror.
+       |""".stripMargin
+  )
+
+  check(
+    "no-import".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |import scala.util.Try
+      |println(42)
+      |```
+      |""".stripMargin,
+    """|```scala
+       |import scala.util.Try
+       |println(42)
+       |// 42
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "import-fail".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |import $scalac.`-Wunused:imports -Xfatal-warnings`
+      |```
+      |```scala mdoc:fail
+      |import scala.util.Try
+      |println(42)
+      |```
+      |""".stripMargin,
+    // NOTE(olafur) I'm not sure if this is the ideal behavior, this test is
+    // only to document the current behavior.
+    """|```scala
+       |import $scalac.`-Wunused:imports -Xfatal-warnings`
+       |```
+       |```scala
+       |import scala.util.Try
+       |println(42)
+       |// error: No warnings can be incurred under -Werror.
+       |```
+       |""".stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
@@ -13,10 +13,10 @@ class ScalacSuite extends BaseMarkdownSuite {
       |println(42)
       |```
       |""".stripMargin,
-    """|warning: import.md:4:1: Unused import
+    """|error: No warnings can be incurred under -Werror.
+       |warning: import.md:4:1: Unused import
        |import scala.util.Try
        |^^^^^^^^^^^^^^^^^^^^^
-       |error: No warnings can be incurred under -Werror.
        |""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -42,8 +42,6 @@ abstract class BaseMarkdownSuite extends tests.BaseSuite {
       )
       .withProperties(MdocProperties.default(PathIO.workingDirectory))
 
-  def postProcessObtained: Map[String, String => String] = Map.empty
-  def postProcessExpected: Map[String, String => String] = Map.empty
   private val myStdout = new ByteArrayOutputStream()
   private def newReporter(): ConsoleReporter = {
     myStdout.reset()
@@ -68,7 +66,7 @@ abstract class BaseMarkdownSuite extends tests.BaseSuite {
       val reporter = newReporter()
       val context = newContext(settings, reporter)
       val input = Input.VirtualFile(name.name + ".md", original)
-      val file = InputFile.fromSettings(input.path, settings)
+      val file = InputFile.fromRelativeFilename(input.path, settings)
       Markdown.toMarkdown(input, context, file, baseSettings.site, reporter, settings)
       assert(reporter.hasErrors, "Expected errors but reporter.hasErrors=false")
       val obtainedErrors = Compat.postProcess(
@@ -92,7 +90,7 @@ abstract class BaseMarkdownSuite extends tests.BaseSuite {
       val reporter = newReporter()
       val context = newContext(settings, reporter)
       val input = Input.VirtualFile(name.name + ".md", original)
-      val file = InputFile.fromSettings(input.path, settings)
+      val file = InputFile.fromRelativeFilename(input.path, settings)
       val obtained =
         Markdown.toMarkdown(input, context, file, baseSettings.site, reporter, settings)
       val colorOut = myStdout.toString()

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -20,7 +20,7 @@ import scala.meta.io.RelativePath
 import munit.TestOptions
 import mdoc.internal.cli.InputFile
 
-abstract class BaseMarkdownSuite extends munit.FunSuite {
+abstract class BaseMarkdownSuite extends tests.BaseSuite {
   override def munitFlakyOK = true
   def createTempDirectory(): AbsolutePath = {
     val dir = AbsolutePath(Files.createTempDirectory("mdoc"))
@@ -111,7 +111,10 @@ abstract class BaseMarkdownSuite extends munit.FunSuite {
       settings: Settings = baseSettings
   )(implicit loc: munit.Location): Unit = {
     checkCompiles(name, original, settings, obtained => {
-      assertNoDiff(obtained, Compat(expected, Map.empty))
+      assertNoDiff(
+        Compat(obtained, Map.empty, postProcessObtained),
+        Compat(expected, Map.empty, postProcessExpected)
+      )
     })
   }
 

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -54,7 +54,7 @@ abstract class BaseMarkdownSuite extends munit.FunSuite {
   private def newContext(settings: Settings, reporter: ConsoleReporter) = {
     settings.validate(reporter)
     if (reporter.hasErrors) fail("reporter has errors")
-    Context(settings, reporter, compiler)
+    Context.fromCompiler(settings, reporter, compiler)
   }
 
   def checkError(

--- a/tests/unit/src/test/scala/tests/markdown/DependencySuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DependencySuite.scala
@@ -1,0 +1,112 @@
+package tests.markdown
+
+class DependencySuite extends BaseMarkdownSuite {
+  val userHome = System.getProperty("user.home")
+  override def postProcessObtained: Map[String, String => String] = Map(
+    "all" -> { old =>
+      old.linesIterator
+        .map {
+          case line if line.contains(userHome) =>
+            "<redacted user.home>"
+          case line => line
+        }
+        .mkString("\n")
+    }
+  )
+  override def munitIgnore: Boolean = mdoc.internal.BuildInfo.scalaBinaryVersion != "2.12"
+
+  List("dep", "ivy").foreach { dep =>
+    check(
+      dep,
+      s"""
+         |```scala mdoc
+         |import $$$dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._
+         |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
+         |```
+         | """.stripMargin,
+      s"""|```scala
+          |import $$$dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._
+          |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
+          |// res0: Either[org.dhallj.core.DhallException.ParsingFailure, org.dhallj.core.Expr] = Right(
+          |//   λ(n : Natural) → [n + 0, n + 1, 1 + 1]
+          |// )
+          |```
+          |""".stripMargin
+    )
+  }
+
+  check(
+    "repo",
+    """
+      |```scala mdoc
+      |import $repo.`https://conjars.org/repo/`
+      |import $dep.`org.conjars.cilquirm:cascading-hbase:1.2.10`
+      |cascading.hbase.HBaseTap.SCHEME
+      |```
+      | """.stripMargin,
+    """|```scala
+       |import $repo.`https://conjars.org/repo/`
+       |import $dep.`org.conjars.cilquirm:cascading-hbase:1.2.10`
+       |cascading.hbase.HBaseTap.SCHEME
+       |// res0: String = "hbase"
+       |```
+       |""".stripMargin
+  )
+
+  checkError(
+    "repo-error",
+    """
+      |```scala mdoc
+      |import $repo.`sbt-plugin:foobar`
+      |println(42)
+      |```
+      | """.stripMargin,
+    """|error: repo-error.md:3:14: sbt-plugin repositories are not supported. Please open a feature request to discuss adding support for sbt-plugin repositories https://github.com/scalameta/mdoc/
+       |import $repo.`sbt-plugin:foobar`
+       |             ^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+
+  checkError(
+    "dep-error",
+    """
+      |```scala mdoc
+      |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
+      |import $dep.`org.scalameta:::not-exists:2.3.4`
+      |import $dep.`org.scalameta::munit:0.7.5` // resolves OK
+      |println(42)
+      |```
+      | """.stripMargin,
+    """|error: dep-error.md:3:49: Error downloading org.scalameta:foobar:1.2.1
+       |<redacted user.home>
+       |  not found: https://repo1.maven.org/maven2/org/scalameta/foobar/1.2.1/foobar-1.2.1.pom
+       |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
+       |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |error: dep-error.md:4:13: Error downloading org.scalameta:not-exists_2.12.11:2.3.4
+       |<redacted user.home>
+       |  not found: https://repo1.maven.org/maven2/org/scalameta/not-exists_2.12.11/2.3.4/not-exists_2.12.11-2.3.4.pom
+       |import $dep.`org.scalameta:::not-exists:2.3.4`
+       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |error: dep-error.md:3:13: Error downloading org.scalameta:mmunit_2.12:2.3.4
+       |<redacted user.home>
+       |  not found: https://repo1.maven.org/maven2/org/scalameta/mmunit_2.12/2.3.4/mmunit_2.12-2.3.4.pom
+       |import $dep.`org.scalameta::mmunit:2.3.4`, $dep.`org.scalameta:foobar:1.2.1`
+       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+  checkError(
+    "dep-syntax-error",
+    """
+      |```scala mdoc
+      |import $dep.`org.scalameta:no-version`
+      |import $dep.`org.scalameta::has-version:1.0.0`
+      |println(42)
+      |```
+      | """.stripMargin,
+    """|error: dep-syntax-error.md:3:13: invalid dependency. To fix this error, use the format `$ORGANIZATION:$ARTIFACT:$NAME`.
+       |import $dep.`org.scalameta:no-version`
+       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -4,6 +4,10 @@ import tests.markdown.StringSyntax._
 
 class FailSuite extends BaseMarkdownSuite {
 
+  override def postProcessExpected: Map[String, String => String] = Map(
+    "2.13" -> { old => old.replace("(fo: F[O])fs2.Stream[F,O]", "(fo: F[O]): fs2.Stream[F,O]") }
+  )
+
   check(
     "mismatch",
     """

--- a/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
@@ -6,11 +6,15 @@ import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.MarkdownCompiler
 import mdoc.internal.markdown.Renderer
 import mdoc.internal.markdown.ReplVariablePrinter
+import mdoc.internal.cli.InputFile
+import mdoc.internal.cli.Settings
+import scala.meta.internal.io.PathIO
 
 class MarkdownCompilerSuite extends FunSuite {
 
   private val compiler = MarkdownCompiler.default()
   private val reporter = ConsoleReporter.default
+  private val settings = Settings.default(PathIO.workingDirectory)
 
   def checkIgnore(name: String, original: String, expected: String): Unit =
     test(name.ignore) {}
@@ -26,7 +30,16 @@ class MarkdownCompilerSuite extends FunSuite {
   ): Unit = {
     test(name) {
       val inputs = original.map(s => Input.String(s))
-      val obtained = Renderer.render(inputs, compiler, reporter, name + ".md", ReplVariablePrinter)
+      val file = InputFile.fromRelativeFilename(name + ".md", settings)
+      val obtained = Renderer.render(
+        file,
+        inputs,
+        compiler,
+        settings,
+        reporter,
+        name + ".md",
+        ReplVariablePrinter
+      )
       assertNoDiff(
         obtained,
         Compat(expected, compat)

--- a/tests/unit/src/test/scala/tests/markdown/MarkdownFileSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MarkdownFileSuite.scala
@@ -21,7 +21,7 @@ class MarkdownFileSuite extends FunSuite {
     test(name) {
       reporter.reset()
       val input = Input.VirtualFile(name, original)
-      val file = InputFile.fromSettings(name, Settings.default(PathIO.workingDirectory))
+      val file = InputFile.fromRelativeFilename(name, Settings.default(PathIO.workingDirectory))
       val obtained = MarkdownFile.parse(input, file, reporter).parts
       require(!reporter.hasErrors)
       val expectedParts = expected.toList

--- a/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
@@ -2,6 +2,9 @@ package tests.markdown
 
 class NestSuite extends BaseMarkdownSuite {
 
+  override def postProcessExpected: Map[String, String => String] = Map(
+    "2.13" -> { old => old.replace("of type => Int", "of type Int") }
+  )
   check(
     "redefine-val",
     """


### PR DESCRIPTION
Previously, mdoc users could not dynamically add new library
dependencies to a document.  The library classpath was static and could
only be updated through the `--classpath` command-line argument.

Now, it's possible for users to dynamically add new dependencies via
imports similar to how it works in Ammonite.

```scala
import $dep.`org.scalameta::scalameta:4.3.10`, scala.meta._
q"val x = 42"
```

The `$ivy` prefix is treated as an alias for `$dep` to preserve
compatibility with Ammonite. However, I went with `$dep` as the primary
syntax instead of `$ivy` because these imports support both Ivy and
Maven patterns. Maybe we can get Ammonite to also support `$dep`.

TODOs:
* [x] expose dependency information in `EvaluatedWorksheet` (required for Metals)
* [x] add support to configure scalac options via imports
* [x] compile errors from `$file` imports
* [x] cyclic dependencies in `$file` imports
* [x] conflicting package names from `$file` imports when the same file is imported from two different packages 