### PR TITLE
Update to latest flexmark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val mdoc = project
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.scalameta" %% "scalameta" % V.scalameta,
       "com.geirsson" %% "metaconfig-typesafe-config" % "0.9.10",
-      "com.vladsch.flexmark" % "flexmark-all" % "0.40.34",
+      "com.vladsch.flexmark" % "flexmark-all" % "0.62.0",
       "com.lihaoyi" %% "fansi" % fansiVersion.value,
       "io.methvin" % "directory-watcher" % "0.9.9",
       "me.xdrop" % "fuzzywuzzy" % "1.2.0", // for link hygiene "did you mean?"

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -1,7 +1,6 @@
 package mdoc.internal.cli
 
 import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.options.MutableDataSet
 import io.methvin.watcher.DirectoryChangeEvent
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption

--- a/mdoc/src/main/scala/mdoc/internal/markdown/GitHubIdGenerator.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/GitHubIdGenerator.scala
@@ -5,6 +5,6 @@ import com.vladsch.flexmark.html.renderer.HeaderIdGenerator
 object GitHubIdGenerator extends (String => String) {
   private def dashChars: String = " -_"
   def apply(header: String): String = {
-    HeaderIdGenerator.generateId(header, dashChars, false)
+    HeaderIdGenerator.generateId(header, dashChars, false, false)
   }
 }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Markdown.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Markdown.scala
@@ -2,14 +2,14 @@ package mdoc.internal.markdown
 
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterBlock
 import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.ast.Document
 import com.vladsch.flexmark.util.ast.Node
 import com.vladsch.flexmark.util.ast.NodeVisitor
 import com.vladsch.flexmark.util.ast.VisitHandler
-import com.vladsch.flexmark.html.HtmlRenderer
-import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.options.DataKey
-import com.vladsch.flexmark.util.options.MutableDataSet
+import com.vladsch.flexmark.util.data.DataKey
+import com.vladsch.flexmark.util.data.MutableDataSet
 import com.vladsch.flexmark.util.sequence.BasedSequence
 import java.nio.file.Files
 import java.nio.file.Paths

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MdocExtensions.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MdocExtensions.scala
@@ -1,6 +1,5 @@
 package mdoc.internal.markdown
 
-import com.vladsch.flexmark.Extension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.definition.DefinitionExtension
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
@@ -11,6 +10,7 @@ import com.vladsch.flexmark.ext.toc.SimTocExtension
 import com.vladsch.flexmark.ext.toc.TocExtension
 import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
+import com.vladsch.flexmark.util.misc.Extension
 import mdoc.internal.cli.Context
 
 object MdocExtensions {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
@@ -4,7 +4,6 @@ import com.vladsch.flexmark.ast.FencedCodeBlock
 import com.vladsch.flexmark.util.ast
 import com.vladsch.flexmark.parser.block.DocumentPostProcessor
 import com.vladsch.flexmark.parser.block.DocumentPostProcessorFactory
-import com.vladsch.flexmark.util.options.MutableDataSet
 import com.vladsch.flexmark.util.sequence.BasedSequence
 import com.vladsch.flexmark.util.sequence.CharSubSequence
 import java.util

--- a/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -1,6 +1,5 @@
 package tests.markdown
 
-import com.vladsch.flexmark.util.options.MutableDataSet
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files

--- a/tests/unit/src/test/scala/tests/markdown/FrontmatterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FrontmatterSuite.scala
@@ -4,7 +4,6 @@ import com.vladsch.flexmark.ext.jekyll.front.matter.JekyllFrontMatterExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.options.MutableDataSet
 import mdoc.internal.markdown.Markdown
 import scala.collection.JavaConverters._
 


### PR DESCRIPTION
Notable, as of 0.60.0 there were some breaking changes and improvements
that are outlined here https://github.com/vsch/flexmark-java/wiki/Version-0.60.0-Changes.

One othere useful thing is that this new version of flexmark uses a newerver version of openhtmltopdf. The old version had some issues where the jar contained paths on the creators machine causing infinite recursion. This ensures that we aren't transitively using that problematic jar in Metals


Supercedes #337 