### PR TITLE
Isolate user classloader from mdoc classloader

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -94,7 +94,16 @@ object MarkdownCompiler {
       if (classpath.isEmpty) defaultClasspath(_ => true)
       else {
         val base = Classpath(classpath)
-        val runtime = defaultClasspath(path => path.toString.contains("mdoc-runtime"))
+        val runtime = defaultClasspath(path => {
+          val pathString = path.toString
+          pathString.contains("scala-library") ||
+          pathString.contains("scala-reflect") ||
+          pathString.contains("sourcecode") ||
+          pathString.contains("fansi") ||
+          pathString.contains("pprint") ||
+          pathString.contains("mdoc-interfaces") ||
+          (pathString.contains("mdoc") && pathString.contains("runtime"))
+        })
         base ++ runtime
       }
     new MarkdownCompiler(fullClasspath.syntax, scalacOptions)
@@ -102,8 +111,9 @@ object MarkdownCompiler {
 
   private def defaultClasspath(fn: Path => Boolean): Classpath = {
     val paths =
-      getURLs(getClass.getClassLoader)
+      getURLs(getClass.getClassLoader).iterator
         .map(url => AbsolutePath(Paths.get(url.toURI)))
+        .filter(p => fn(p.toNIO))
     Classpath(paths.toList)
   }
 

--- a/tests/unit/src/test/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseSuite.scala
@@ -17,9 +17,12 @@ class BaseSuite extends FunSuite {
     )
   }
   object OnlyScala213 extends munit.Tag("OnlyScala213")
+  object SkipScala211 extends munit.Tag("SkipScala211")
   override def munitTestTransforms: List[TestTransform] = super.munitTestTransforms ++ List(
     new TestTransform(OnlyScala213.value, { test =>
       if (test.tags(OnlyScala213) && mdoc.internal.BuildInfo.scalaBinaryVersion != "2.13")
+        test.tag(munit.Ignore)
+      else if (test.tags(SkipScala211) && mdoc.internal.BuildInfo.scalaBinaryVersion == "2.11")
         test.tag(munit.Ignore)
       else test
     })

--- a/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/BaseCliSuite.scala
@@ -47,7 +47,7 @@ abstract class BaseCliSuite extends BaseSuite {
       expectedExitCode: => Int = 0,
       onStdout: String => Unit = _ => (),
       includeOutputPath: RelativePath => Boolean = _ => true
-  ): Unit = {
+  )(implicit loc: munit.Location): Unit = {
     test(name) {
       myStdout.reset()
       StringFS.fromString(original, in())

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -238,4 +238,20 @@ class WorksheetSuite extends FunSuite {
        |""".stripMargin
   )
 
+  checkDecorations(
+    "fastparse",
+    """
+      |import $dep.`com.lihaoyi::fastparse:2.3.0`
+      |import fastparse._, MultiLineWhitespace._
+      |def p[_:P] = P("a")
+      |parse("a", p(_))
+      |""".stripMargin,
+    """|import $dep.`com.lihaoyi::fastparse:2.3.0`
+       |import fastparse._, MultiLineWhitespace._
+       |def p[_:P] = P("a")
+       |<parse("a", p(_))> // Success((), 1)
+       |res0: Parsed[Unit] = Success((), 1)
+       |""".stripMargin
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -8,8 +8,10 @@ import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import mdoc.internal.pos.PositionSyntax._
 import java.{util => ju}
+import tests.BaseSuite
+import munit.TestOptions
 
-class WorksheetSuite extends FunSuite {
+class WorksheetSuite extends BaseSuite {
   var mdoc = ju.ServiceLoader
     .load(classOf[Mdoc], this.getClass().getClassLoader())
     .iterator()
@@ -21,14 +23,14 @@ class WorksheetSuite extends FunSuite {
   }
 
   def checkDiagnostics(
-      name: String,
+      options: TestOptions,
       original: String,
       expected: String
   ): Unit = {
-    test(name) {
-      val filename = name + ".scala"
+    test(options) {
+      val filename = options.name + ".scala"
       val worksheet = mdoc.evaluateWorksheet(filename, original)
-      val input = Input.VirtualFile(name, original)
+      val input = Input.VirtualFile(options.name, original)
       val out = new StringBuilder()
       var i = 0
       val diagnostics =
@@ -51,15 +53,15 @@ class WorksheetSuite extends FunSuite {
   }
 
   def checkDecorations(
-      name: String,
+      options: TestOptions,
       original: String,
       expected: String
   ): Unit = {
-    test(name) {
-      val filename = name + ".scala"
+    test(options) {
+      val filename = options.name + ".scala"
       val worksheet = mdoc.evaluateWorksheet(filename, original)
       val statements = worksheet.statements().asScala.sortBy(_.position().startLine())
-      val input = Input.VirtualFile(name, original)
+      val input = Input.VirtualFile(options.name, original)
       val out = new StringBuilder()
       var i = 0
       statements.foreach { stat =>
@@ -239,7 +241,7 @@ class WorksheetSuite extends FunSuite {
   )
 
   checkDecorations(
-    "fastparse",
+    "fastparse".tag(SkipScala211),
     """
       |import $dep.`com.lihaoyi::fastparse:2.3.0`
       |import fastparse._, MultiLineWhitespace._


### PR DESCRIPTION
Fixes #346. Previously, mdoc leaked the mdoc classpath into the user's
code at runtime which could result in runtime crashes if the user code
had dependencies that conflict with mdoc's dependencies (such as
fastparse). Now, mdoc isolates the mdoc classpath to prevent these
conflicts.