### PR TITLE
Add -1 for any diagnostics using point() in Scala 3

### DIFF
--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -150,26 +150,21 @@ class MarkdownCompiler(
 
   private def toMetaPosition(
       edit: TokenEditDistance,
-      pos: java.util.Optional[SourcePosition]
+      position: SourcePosition
   ): Position = {
-    if (pos.isPresent) {
-      val position = pos.get
-      def toOffsetPosition(offset: Int): Position = {
-        edit.toOriginal(offset) match {
-          case Left(_) =>
-            Position.None
-          case Right(p) =>
-            p.toUnslicedPosition
-        }
+    def toOffsetPosition(offset: Int): Position = {
+      edit.toOriginal(offset) match {
+        case Left(_) =>
+          Position.None
+        case Right(p) =>
+          p.toUnslicedPosition
       }
-      (edit.toOriginal(pos.get.start), edit.toOriginal(pos.get.end - 1)) match {
-        case (Right(start), Right(end)) =>
-          Position.Range(start.input, start.start, end.end).toUnslicedPosition
-        case (_, _) =>
-          toOffsetPosition(pos.get.point)
-      }
-    } else {
-      Position.None
+    }
+    (edit.toOriginal(position.start), edit.toOriginal(position.end - 1)) match {
+      case (Right(start), Right(end)) =>
+        Position.Range(start.input, start.start, end.end).toUnslicedPosition
+      case (_, _) =>
+        toOffsetPosition(position.point - 1)
     }
   }
 
@@ -187,7 +182,7 @@ class MarkdownCompiler(
       case diagnostic if diagnostic.position.isPresent =>
         val pos = diagnostic.position.get
         val msg = nullableMessage(diagnostic.message)
-        val mpos = toMetaPosition(edit,java.util.Optional.of(pos))
+        val mpos = toMetaPosition(edit, pos)
         val actualMessage =
           if (mpos == Position.None) {
             val line = pos.lineContent

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -329,6 +329,23 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
+  checkDiagnostics(
+    "dotty-ambiguous-implicit".tag(OnlyScala3),
+    """|abstract class C:
+       |  val x: Int
+       |given c1 as C:
+       |  val x = 1
+       |given c2 as C:
+       |  val x = 2
+       |def fn(using c: C) = ()
+       |val xx = fn
+       |""".stripMargin,
+    """|dotty-ambiguous-implicit:8:10: error: ambiguous implicit arguments: both object c1 in class App and object c2 in class App match type App.this.C of parameter c of method fn in class App
+       |val xx = fn
+       |         ^^
+       |""".stripMargin
+  )
+
   checkDecorations(
     "dotty-imports".tag(OnlyScala3),
     """|import $dep.`com.lihaoyi:scalatags_2.13:0.9.1`


### PR DESCRIPTION
This came up in case of ambigous implicits:
```
-- Error: dotty-interpolation.scala:23:15 --------------------------------------
23 |    val xx = fn    
   |               ^
   |ambiguous implicit arguments: both object c1 in class App and object c2 in class App match type App.this.C of parameter c of method fn in class App
```
diagnostic seems to be pointing to the place the parameters are supposed to be, which is not a real position. We need to do -1 in those cases, though not 100% sure it will work in every situation, but we can fix it as we find more issues.