### PR TITLE
Filter out placeholders so they aren't bound in Dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import scala.collection.mutable
 
-def scala212 = "2.12.11"
+def scala212 = "2.12.12"
 def scala211 = "2.11.12"
-def scala213 = "2.13.2"
+def scala213 = "2.13.3"
 def scala3 = List("0.26.0", "0.27.0-RC1")
 
 def scalajs = "1.1.1"

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -143,8 +143,8 @@ object Instrumenter {
 
   object Binders {
     private def fromPat(trees: List[Tree])(using ctx: Context) = {
-      trees.map {
-        case id: Ident =>
+      trees.collect {
+        case id: Ident if id.name.toString != "_" => // ignore placeholders
           id.name.toString -> id.sourcePos
       }
     }

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -35,7 +35,6 @@ class WorksheetProvider(settings: Settings) {
     val compiler = ctx.compiler(instrumented)
     val rendered =
       MarkdownBuilder.buildDocument(compiler, reporter, sectionInputs, instrumented, input.path)
-
     val decorations = for {
       section <- rendered.sections.iterator
       statement <- section.section.statements

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -353,6 +353,17 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
+  checkDecorations(
+    "placeholder",
+    """|def x = 1 -> 2
+       |val (a, _) = x
+       |""".stripMargin,
+    """|def x = 1 -> 2
+       |<val (a, _) = x> // : Int = 1
+       |a: Int = 1
+       |""".stripMargin
+  )
+
   def checkDiagnostics(
       options: TestOptions,
       original: String,


### PR DESCRIPTION
This is to address the issue outlined [here in Metals](https://github.com/scalameta/metals/issues/2076) where there was issues in worksheets with trying to bind placeholders.

I want to _assume_ that there is a nicer way to do this than just matching like I did? I was looking for like a `Tree.placeholder` method or something cleaner?