### PR TITLE
Use ssh key saved in ssh-agent if deploy key env var is not set. Fixes #398

### DIFF
--- a/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
@@ -57,7 +57,7 @@ object DocusaurusPlugin extends AutoPlugin {
     """|#!/usr/bin/env bash
        |
        |set -eu
-       |DEPLOY_KEY=${GIT_DEPLOY_KEY:-$GITHUB_DEPLOY_KEY}
+       |DEPLOY_KEY=${GIT_DEPLOY_KEY:-${GITHUB_DEPLOY_KEY:-}}
        |set-up-ssh() {
        |  echo "Setting up ssh..."
        |  mkdir -p $HOME/.ssh
@@ -75,7 +75,7 @@ object DocusaurusPlugin extends AutoPlugin {
        |if [[ -n "${DEPLOY_KEY:-}" ]]; then
        |  set-up-ssh
        |else
-       |  echo "Can't setup SSH. To fix this problem, set the GIT_DEPLOY_KEY environment variable."
+       |  echo "No deploy key found. Attempting to auth with ssh key saved in ssh-agent. To use a deploy key instead, set the GIT_DEPLOY_KEY environment variable."
        |fi
        |
        |yarn install


### PR DESCRIPTION
@olafurpg Thanks for the pointer in #398, I think this should fix it.

- If neither env variable is found, we now set `DEPLOY_KEY` to empty string instead of throwing an error.
- Code proceeds to `if [[ -n "${DEPLOY_KEY:-}" ]]; then`. This checks that `DEPLOY_KEY` is set AND non-empty, so this check fails, and the code proceeds into `else`, where a warning is printed.
- Code then proceeds to run `yarn install` etc. If you have `ssh-add`-ed an ssh key like I do locally, this will use that key, and your name & email (not docusaurus info from `set-up-ssh`), which... I guess is appropriate given that your personal key is used?

This change works for me, I tested by running this script locally on bash 3.2.

I thought about updating the docs to indicate this new behaviour, but the way they read heavily implies this new behaviour already I think.