### PR TITLE
Revert sbt back to 2.13.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.3.13


### PR DESCRIPTION
Ugh, sorry my mistake. I keep doing this. I saw that everything was all green on the build and celebrated a bit too early. While all the CI tests pass with this, the release job fails. I'm going to go ahead and merge this right away in order to revert and have the release job run correctly.

My apologies.