### PR TITLE
Upgrade to latest Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ def scala211 = "2.11.12"
 def scala213 = "2.13.3"
 def scala3 = List("3.0.0-M1")
 
-def scalajs = "1.1.1"
+def scalajs = "1.3.0"
 def scalajsBinaryVersion = "1"
-def scalajsDom = "1.0.0"
+def scalajsDom = "1.1.0"
 
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 def isScala212(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2) && v.exists(_._2 == 12)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")
 
 libraryDependencies ++= List(


### PR DESCRIPTION
Previously, the `mdoc:js` modifier didn't work with libraries that were compiled with Scala.js 1.3.0. 