### PR TITLE
Store compilers with dependencies *and* scalacOptions.

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/cli/Context.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/Context.scala
@@ -16,13 +16,15 @@ case class Context(
     settings: Settings,
     reporter: Reporter,
     compiler: MarkdownCompiler,
-    compilers: mutable.Map[Set[Dependency], MarkdownCompiler] = mutable.Map.empty
+    compilers: mutable.Map[(Set[Dependency], List[String]), MarkdownCompiler] = mutable.Map.empty
 ) {
-  def compiler(instrumented: Instrumented) =
+  def compiler(instrumented: Instrumented) = {
+    val scalacOptions = instrumented.scalacOptionImports.map(_.value)
     compilers.getOrElseUpdate(
-      instrumented.dependencies,
+      (instrumented.dependencies, scalacOptions),
       Dependencies.newCompiler(settings, instrumented)
     )
+  }
 }
 
 object Context {


### PR DESCRIPTION
The main reason behind this change is that in Metals when a user adds or
removes a `$scalac`  magic import, it has no affect unless they close
Metals and restart it. This leads to people assuming that the `$scalac`
imports aren't working in Metals.

This is because when we do a looking into the ctx compilers we are only
taking into consideration the dependencies instead of the scalacOptions.
This slight changes just makes the key `(Dependencies, scalacOptions)`
instead of `Dependencies` so that when a user changes the `$scalac`
import, it's taken into consideration when doing the lookup or providing
a new compiler.

Address the following comment in #397 

> I think this doesn't work in worksheets as far as I tried, not sure exactly why.


Old Behavior (appears that it isn't working)

![2020-11-28 13 40 20](https://user-images.githubusercontent.com/13974112/100515849-56b14d80-317f-11eb-8c91-a768fbb7dec7.gif)

New Behavior

![2020-11-28 13 38 25](https://user-images.githubusercontent.com/13974112/100515859-6c267780-317f-11eb-8556-6ff20fd8bb16.gif)
