### PR TITLE
Add in an exportable evaluation to the `EvaluatedWorksheet`.

### DIFF
--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedWorksheet.java
@@ -1,6 +1,7 @@
 package mdoc.interfaces;
 
 import java.util.List;
+import java.util.Optional;
 import java.nio.file.Path;
 import coursierapi.Dependency;
 import coursierapi.Repository;
@@ -15,5 +16,5 @@ public abstract class EvaluatedWorksheet {
   public abstract List<Path> classpath();
   public abstract List<Dependency> dependencies();
   public abstract List<Repository> repositories();
-
+  public abstract Optional<String> exportableEvaluation();
 }

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/EvaluatedWorksheet.scala
@@ -11,5 +11,6 @@ case class EvaluatedWorksheet(
     val scalac: ju.List[String],
     val classpath: ju.List[Path],
     val dependencies: ju.List[coursierapi.Dependency],
-    val repositories: ju.List[coursierapi.Repository]
+    val repositories: ju.List[coursierapi.Repository],
+    val exportableEvaluation: ju.Optional[String]
 ) extends mdoc.interfaces.EvaluatedWorksheet

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -382,6 +382,24 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
+  checkExportableEvaluations(
+    "simple",
+    "val x = 3",
+    ju.Optional.of("val x = 3 // : Int = 3")
+  )
+
+  checkExportableEvaluations(
+    "continuation",
+    """val x = println("badabing\nbadaboom")""",
+    ju.Optional.of("""val x = println("badabing\nbadaboom") // badabing…""")
+  )
+
+  checkExportableEvaluations(
+    "no-export",
+    "val x: Int = a",
+    ju.Optional.empty()
+  )
+
   def checkDiagnostics(
       options: TestOptions,
       original: String,
@@ -448,6 +466,20 @@ class WorksheetSuite extends BaseSuite {
       }
       val obtained = out.toString()
       assertNoDiff(obtained, Compat(expected, compat))
+    }
+  }
+
+  def checkExportableEvaluations(
+      options: TestOptions,
+      original: String,
+      expected: ju.Optional[String],
+      compat: Map[String, String] = Map.empty
+  ): Unit = {
+    test(options) {
+      val filename = options.name + ".scala"
+      val worksheet = mdoc.evaluateWorksheet(filename, original)
+      val output = worksheet.exportableEvaluation
+      assertEquals(output, expected)
     }
   }
 }


### PR DESCRIPTION
The purpose for this change in twofold.

1. The first usecase would be for a user to be able to be in a worksheet
   in Metals, evaluate something, and then want to export the worksheet
   plus decorations. This will allow for Metals to easily extract the
     evaluation with "decorations".

Given:

```scala
val a = 3
val b = println("hey\nyo")
```

Would return:

```scala
val a = 3 // : Int = 3
val b = println("hey\nyo") // hey…
```

If there are any diagnostics errors, then it will just return a
`Optional.empty` rather than the `Optional[String]`.

You can see an example of this use case [here](https://github.com/scalameta/metals/pull/2290).

2. The second use case will be upcoming, but it will be able to be used
   to ensure that projects (many times educational) that rely on a lot
   of worksheets will have an easy way to quickly check to make sure
   that statements and expressions are still evaluating and returning. I
   hope to just be able to re-use this functionality for that.