### PR TITLE
Add Markdown files to `watchTriggers` SBT setting

### DIFF
--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -76,6 +76,7 @@ object MdocPlugin extends AutoPlugin {
       mdocJSLibraries := Nil,
       mdocAutoDependency := true,
       mdocInternalVariables := Nil,
+      watchTriggers += mdocIn.value.toGlob / "*.md",
       mdoc := Def.inputTaskDyn {
         validateSettings.value
         val parsed = sbt.complete.DefaultParsers.spaceDelimited("<arg>").parsed


### PR DESCRIPTION
After this change we can use the standard SBT `~myProject/mdoc` to re-launch `mdoc` in the project `myProject` after any change in a Markdown file inside the `mdocIn` folder.

Reference: https://www.scala-sbt.org/1.x/docs/Triggered-Execution.html#Configuration