### PR TITLE
snarf system streams as well as scala console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,7 @@ inThisBuild(
       )
     ),
     testFrameworks := List(new TestFramework("munit.Framework")),
+    Test / parallelExecution := false,
     resolvers += Resolver.sonatypeRepo("public"),
     // faster publishLocal:
     publishArtifact.in(packageDoc) := "true" == System.getenv("CI"),

--- a/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
+++ b/runtime/src/main/scala/mdoc/internal/document/DocumentBuilder.scala
@@ -85,8 +85,20 @@ trait DocumentBuilder {
     def build(input: InstrumentedInput): Document = {
       try {
         Console.withOut(myPs) {
-          Console.withErr(myPs) {
-            app()
+          val oldOut = System.out
+          try {
+            System.setOut(myPs)
+            Console.withErr(myPs) {
+              val oldErr = System.err
+              try {
+                System.setErr(myPs)
+                app()
+              } finally {
+                System.setErr(oldErr)
+              }
+            }
+          } finally {
+            System.setOut(oldOut)
           }
         }
       } catch {

--- a/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/MarkdownCompilerSuite.scala
@@ -113,6 +113,7 @@ class MarkdownCompilerSuite extends FunSuite {
       |  2
       |}
       |// 42
+      |// err
       |// 52
       |// x: Int = 2
       |```

--- a/tests/unit/src/test/scala/tests/markdown/SystemStreams.scala
+++ b/tests/unit/src/test/scala/tests/markdown/SystemStreams.scala
@@ -1,0 +1,35 @@
+package tests.markdown
+
+class SystemStreamsSuite extends BaseMarkdownSuite {
+
+  check(
+    "System.out",
+    """
+      |```scala mdoc
+      |System.out.println("hello out")
+      |```
+      """.stripMargin,
+    """
+      |```scala
+      |System.out.println("hello out")
+      |// hello out
+      |```
+      """.stripMargin
+  )
+
+  check(
+    "System.err",
+    """
+      |```scala mdoc
+      |System.err.println("hello err")
+      |```
+      """.stripMargin,
+    """
+      |```scala
+      |System.err.println("hello err")
+      |// hello err
+      |```
+      """.stripMargin
+  )
+
+}


### PR DESCRIPTION
mdoc only captures output to `scala.Console` but lots of stuff (notably `cats.effect.std.Console` in CE3) writes to the Java system streams. This attempts to fix it.

All the individual tests seem to work from metals, but `sbt test` hangs on my machine for some reason so it's possible this doesn't work.