### PR TITLE
Update scalameta to 4.4.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ lazy val sharedSettings = List(
 )
 
 val V = new {
-  val scalameta = "4.4.0"
+  val scalameta = "4.4.4"
   val munit = "0.7.20"
   val coursier = "1.0.2"
   val scalacheck = "1.15.2"

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Processor.scala
@@ -33,10 +33,7 @@ object MdocDialect {
   def parse(path: AbsolutePath): Parsed[Source] = {
     scala(Input.VirtualFile(path.toString(), path.readText)).parse[Source]
   }
-  val scala = Scala213.copy(
-    allowToplevelTerms = true,
-    toplevelSeparator = ""
-  )
+  val scala = Scala213.withAllowToplevelTerms(true)
 }
 
 class Processor(implicit ctx: Context) {

--- a/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/PositionSyntax.scala
@@ -135,8 +135,20 @@ object PositionSyntax {
           .append("\n")
           .append(pos.lineContent)
           .append("\n")
-          .append(pos.lineCaret)
+          .append(lineCaret(pos))
           .toString
+    }
+
+  private def lineCaret(pos: Position): String =
+    pos match {
+      case Position.None =>
+        ""
+      case _ =>
+        val caret =
+          if (pos.start == pos.end) "^"
+          else if (pos.startLine == pos.endLine) "^" * (pos.end - pos.start)
+          else "^"
+        (" " * pos.startColumn) + caret
     }
 
   implicit class XtensionPositionsScalafix(private val pos: Position) extends AnyVal {
@@ -156,31 +168,6 @@ object PositionSyntax {
     def rangeNumber: String =
       s"${pos.startLine + 1}:${pos.startColumn + 1}..${pos.endLine + 1}:${pos.endColumn + 1}"
 
-    def lineCaret: String =
-      pos match {
-        case Position.None =>
-          ""
-        case _ =>
-          val caret =
-            if (pos.start == pos.end) "^"
-            else if (pos.startLine == pos.endLine) "^" * (pos.end - pos.start)
-            else "^"
-          (" " * pos.startColumn) + caret
-      }
-
-    def lineContent: String =
-      pos match {
-        case Position.None => ""
-        case range: Position.Range =>
-          val pos = Position.Range(
-            range.input,
-            range.startLine,
-            0,
-            range.startLine,
-            Int.MaxValue
-          )
-          pos.text
-      }
   }
 
   implicit class XtensionThrowable(e: Throwable) {

--- a/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
+++ b/mdoc/src/main/scala/mdoc/internal/pos/TokenEditDistance.scala
@@ -75,7 +75,7 @@ object TokenEditDistance {
 
   implicit val dialect: scala.meta.Dialect =
     if (BuildInfo.scalaBinaryVersion.startsWith("2.")) scala.meta.dialects.Scala213
-    else scala.meta.dialects.Dotty
+    else scala.meta.dialects.Scala3
 
   lazy val empty: TokenEditDistance = new TokenEditDistance(Array.empty)
 


### PR DESCRIPTION
While updating it I also removed some deprecated usages of `Dotty` dialect and the dialect.copy method. Default toplevelSeparator
is "" so I removed that too.

There we also some issues with the newely added lineCaret and lineContent methods added in 4.4.3 in
https://github.com/scalameta/scalameta/pull/2197 , since such methods already existed in mdoc. I remvoed the lineContent one
and kept the lineCaret as a private method, because it's logic is a bit different than the scalameta one.