### PR TITLE
Update scala 2.12 to 2.12.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         java: [adopt@1.8, adopt@1.11]
         command:
           - "'++2.11.12 test'"
-          - "'++2.12.12 test' scripted"
+          - "'++2.12.13 test' scripted"
           - "'++2.13.4 test'"
           - "'++3.0.0-M2 test'"
           - "'++3.0.0-M3 test'"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import scala.collection.mutable
 
-def scala212 = "2.12.12"
+def scala212 = "2.12.13"
 def scala211 = "2.11.12"
 def scala213 = "2.13.4"
 def scala3 = List("3.0.0-M3", "3.0.0-M2")

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion.in(ThisBuild) := "2.12.8"
+scalaVersion.in(ThisBuild) := "2.12.13"
 
 enablePlugins(MdocPlugin)
 mdocJS := Some(jsapp)

--- a/mdoc/src/main/scala-2.12/mdoc/internal/markdown/VersionSpecificFilteringReporter.scala
+++ b/mdoc/src/main/scala-2.12/mdoc/internal/markdown/VersionSpecificFilteringReporter.scala
@@ -1,11 +1,10 @@
 package mdoc.internal.markdown
 
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.AbstractReporter
+import scala.tools.nsc.reporters.FilteringReporter
 import scala.reflect.internal.util.Position
 
-trait VersionSpecificFilteringReporter extends AbstractReporter { self: FilterStoreReporter =>
-  override def display(pos: Position, msg: String, severity: Severity): Unit =
+trait VersionSpecificFilteringReporter extends FilteringReporter { self: FilterStoreReporter =>
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit =
     add(pos, msg, severity)
-  override def displayPrompt(): Unit = ()
 }


### PR DESCRIPTION
It seems that we are once again hit by:
```
[error] (run-main-0) java.lang.NoClassDefFoundError: scala/tools/nsc/reporters/AbstractReporter
[error] java.lang.NoClassDefFoundError: scala/tools/nsc/reporters/AbstractReporter
[error]         at java.lang.ClassLoader.defineClass1(Native Method)
[error]         at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
[error]         at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
[error]         at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
[error]         at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
[error]         at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
[error]         at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
[error]         at java.security.AccessController.doPrivileged(Native Method)
[error]         at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
[error] Caused by: java.lang.ClassNotFoundException: scala.tools.nsc.reporters.AbstractReporter
[error]         at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
```

which is similar to https://github.com/scalameta/mdoc/issues/195

I updated the version to 2.12.13 as was the case in the previous issue. Needed for https://github.com/scalameta/metals/pull/2383