### PR TITLE
Allow controlling linker re-use on Scala.js

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -395,3 +395,18 @@ files:
   the markdown output as a `<script src="...">`.
 - `*-loader.js`: same as `*-library.js` but it comes after `*-library.js`.
 - `*.js.map`: optional source maps.
+
+### Batch mode linking
+
+By default, mdoc will re-use the Scala.js linker, exercising its ability to work
+incrementally. This can speed up linking and optimization dramatically.
+
+If incremental linking is causing issues in your project, use can use `js-batch-mode`
+site variable to enable batch mode (which will discard intermediate linker state 
+after processing each file):
+
+```scala
+mdocVariables := Map(
+  "js-batch-mode" -> "true"
+)
+```

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
@@ -19,7 +19,8 @@ case class JsConfig(
     outPrefix: Option[String] = None,
     fullOpt: Boolean = true,
     htmlPrefix: String = "",
-    relativeLinkPrefix: String = ""
+    relativeLinkPrefix: String = "",
+    reuseLinker: Boolean = true
 ) {
   def isCommonJS: Boolean = moduleKind == ModuleKind.CommonJSModule
   def libraryScripts(
@@ -90,7 +91,8 @@ object JsConfig {
               !ctx.settings.watch
           }
       },
-      relativeLinkPrefix = ctx.site.getOrElse("js-relative-link-prefix", base.relativeLinkPrefix)
+      relativeLinkPrefix = ctx.site.getOrElse("js-relative-link-prefix", base.relativeLinkPrefix),
+      reuseLinker = ctx.site.getOrElse("js-reuse-linker", "true").toBoolean
     )
   }
 }

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsConfig.scala
@@ -20,7 +20,7 @@ case class JsConfig(
     fullOpt: Boolean = true,
     htmlPrefix: String = "",
     relativeLinkPrefix: String = "",
-    reuseLinker: Boolean = true
+    batchMode: Boolean = false
 ) {
   def isCommonJS: Boolean = moduleKind == ModuleKind.CommonJSModule
   def libraryScripts(
@@ -92,7 +92,7 @@ object JsConfig {
           }
       },
       relativeLinkPrefix = ctx.site.getOrElse("js-relative-link-prefix", base.relativeLinkPrefix),
-      reuseLinker = ctx.site.getOrElse("js-reuse-linker", "true").toBoolean
+      batchMode = ctx.site.getOrElse("js-batch-mode", "false").toBoolean
     )
   }
 }

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -29,6 +29,7 @@ import org.scalajs.linker.interface.LinkerOutput
 import org.scalajs.linker.MemOutputFile
 import java.util.concurrent.Executor
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalajs.linker.interface.ClearableLinker
 
 class JsModifier extends mdoc.PreModifier {
   override val name = "js"
@@ -37,7 +38,7 @@ class JsModifier extends mdoc.PreModifier {
   val target = new VirtualDirectory("(memory)", None)
   var maybeCompiler: Option[MarkdownCompiler] = None
   var config = JsConfig()
-  var linker: Linker = newLinker()
+  var linker: ClearableLinker = newLinker()
   var virtualIrFiles: Seq[IRFile] = Nil
   var classpathHash: Int = 0
   var reporter: mdoc.Reporter = new ConsoleReporter(System.out)
@@ -67,7 +68,7 @@ class JsModifier extends mdoc.PreModifier {
     result
   }
 
-  def newLinker(): Linker = {
+  def newLinker(): ClearableLinker = {
     val semantics: Semantics =
       if (config.fullOpt) Semantics.Defaults.optimized
       else Semantics.Defaults
@@ -76,9 +77,10 @@ class JsModifier extends mdoc.PreModifier {
       .withSemantics(semantics)
       .withSourceMap(false)
       .withModuleKind(config.moduleKind)
+      .withBatchMode(config.batchMode)
       .withClosureCompilerIfAvailable(config.fullOpt)
 
-    StandardImpl.linker(conf)
+    StandardImpl.clearableLinker(conf)
   }
 
   override def onLoad(ctx: OnLoadContext): Unit = {
@@ -165,9 +167,8 @@ class JsModifier extends mdoc.PreModifier {
     } else {
       val output = MemOutputFile.apply()
 
-      val currentLinker = if (config.reuseLinker) linker else newLinker()
       val linking =
-        currentLinker.link(virtualIrFiles ++ sjsir, Nil, LinkerOutput.apply(output), sjsLogger)
+        linker.link(virtualIrFiles ++ sjsir, Nil, LinkerOutput.apply(output), sjsLogger)
       Await.result(linking, Duration.Inf)
 
       ctx.settings.toInputFile(ctx.inputFile) match {

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -165,7 +165,9 @@ class JsModifier extends mdoc.PreModifier {
     } else {
       val output = MemOutputFile.apply()
 
-      val linking = linker.link(virtualIrFiles ++ sjsir, Nil, LinkerOutput.apply(output), sjsLogger)
+      val currentLinker = if (config.reuseLinker) linker else newLinker()
+      val linking =
+        currentLinker.link(virtualIrFiles ++ sjsir, Nil, LinkerOutput.apply(output), sjsLogger)
       Await.result(linking, Duration.Inf)
 
       ctx.settings.toInputFile(ctx.inputFile) match {


### PR DESCRIPTION
This allows users to work around #454 (which is just scala-js/scala-js#4416 wearing a fake mustache) at the cost of some speed penalty

How did I test this?

pre-req: Publish this branch locally

1. Via the reproduction script https://github.com/keynmol/mdoc-scalajs-problem/blob/master/repro.sh:

**js-batch-mode=true**

```
❯ MDOC_VERSION_OVERRIDE='2.2.16+9-c9f6ccba+20210206-2044-SNAPSHOT' MDOC_BATCH_MODE=true ./repro.sh
/tmp/tmp.mglK52yk6v
Using the following mdoc.properties:
js-classpath=/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-library_2.13/1.3.0/scalajs-library_2.13-1.3.0.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.3/scala-library-2.13.3.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-dom_sjs1_2.13/1.1.0/scalajs-dom_sjs1_2.13-1.1.0.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-library_2.13/1.0.0/scalajs-library_2.13-1.0.0.jar
js-scalac-options=-Xplugin:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-compiler_2.13.3/1.3.0/scalajs-compiler_2.13.3-1.3.0.jar
js-batch-mode=true
info: Compiling 3 files to /tmp/tmp.9QxaoKSvcu
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Compiled in 4.84s (0 errors)
```

**js-batch-mode=false** (default)
```
❯ MDOC_VERSION_OVERRIDE='2.2.16+9-c9f6ccba+20210206-2044-SNAPSHOT' MDOC_BATCH_MODE=false ./repro.sh
/tmp/tmp.lSDzmvB2cH
Using the following mdoc.properties:
js-classpath=/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-library_2.13/1.3.0/scalajs-library_2.13-1.3.0.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.3/scala-library-2.13.3.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-dom_sjs1_2.13/1.1.0/scalajs-dom_sjs1_2.13-1.1.0.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-library_2.13/1.0.0/scalajs-library_2.13-1.0.0.jar
js-scalac-options=-Xplugin:/home/velvetbaldmime/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-js/scalajs-compiler_2.13.3/1.3.0/scalajs-compiler_2.13.3-1.3.0.jar
js-batch-mode=false
info: Compiling 3 files to /tmp/tmp.UeNPg3lZB8
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: JSC_UNDEFINED_VARIABLE. variable $c_s_util_Success is undeclared at virtualfile:a.md line 11 : 7
info: Closure: 1 error(s), 0 warning(s)
error: mdoc:js exception
mdoc.internal.markdown.ModifierException: mdoc:js exception
Caused by: org.scalajs.linker.interface.LinkingException: There were errors when applying the Google Closure Compiler
        at org.scalajs.linker.backend.closure.ClosureLinkerBackend.compile(ClosureLinkerBackend.scala:136)
        at org.scalajs.linker.backend.closure.ClosureLinkerBackend.$anonfun$emit$5(ClosureLinkerBackend.scala:105)
        at org.scalajs.logging.Logger.time(Logger.scala:42)
        at org.scalajs.logging.Logger.time$(Logger.scala:40)
        at mdoc.modifiers.JsModifier$$anon$1.time(JsModifier.scala:47)
        at org.scalajs.linker.backend.closure.ClosureLinkerBackend.$anonfun$emit$3(ClosureLinkerBackend.scala:94)
        at scala.Option.map(Option.scala:242)
        at org.scalajs.linker.backend.closure.ClosureLinkerBackend.emit(ClosureLinkerBackend.scala:88)
        at org.scalajs.linker.standard.StandardLinkerImpl.$anonfun$link$2(StandardLinkerImpl.scala:47)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:434)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
info: Compiled in 3.8s (1 error)

```

2. Tested on https://github.com/raquo/Laminar master branch, by using locally published mdoc version:

```diff
diff --git a/build.sbt b/build.sbt
index 32ef275..e270850 100644
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val website = project
     mdocJSLibraries := webpack.in(websiteJS, Compile, fullOptJS).value,
     skip in publish := true,
     mdocVariables := Map(
-      "js-mount-node" -> "containerNode"
+      "js-mount-node" -> "containerNode",
+      "js-batch-mode" -> "true"
       //  // Use these as @VERSION@ in mdoc-processed .md files
       //  "LAMINAR_VERSION" -> version.value.replace("-SNAPSHOT", ""), // This can return incorrect version too easily
       //  "SCALA_VERSION" -> scalaVersion.value
diff --git a/project/plugins.sbt b/project/plugins.sbt
index a8522ca..6498675 100644
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")

-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.9" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.16+9-c9f6ccba+20210206-2044-SNAPSHOT" )
```

```
sbt:Laminar> website/docusaurusCreateSite
[info] running mdoc.Main
info: Compiling 9 files to /home/velvetbaldmime/projects/Laminar/website/target/mdoc
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Closure: 0 error(s), 0 warning(s)
info: Compiled in 24s (0 errors)
yarn install v1.22.10
.....
```