### PR TITLE
Make sure that evalaution runs with a proper classloader

### DIFF
--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -373,6 +373,22 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
+    "akka".tag(SkipScala3).tag(SkipScala211),
+    """|import $dep.`com.typesafe.akka::akka-actor:2.6.13`
+       |import akka.actor.ActorSystem
+       |
+       |implicit val system = ActorSystem("worksheet")
+       |
+       |""".stripMargin,
+    """|import $dep.`com.typesafe.akka::akka-actor:2.6.13`
+       |import akka.actor.ActorSystem
+       |
+       |<implicit val system = ActorSystem("worksheet")> // : ActorSystem = akka...
+       |system: ActorSystem = akka://worksheet
+       |""".stripMargin
+  )
+
+  checkDecorations(
     "placeholder",
     """|def x = 1 -> 2
        |val (a, _) = x


### PR DESCRIPTION
Previously, we would run evalaution with the default mdoc classloader, which might have not contained things like default akka config. Now, we run it in a Thread with the specific classloader set.

Fixes https://github.com/scalameta/metals/issues/2525