### PR TITLE
Update Scala.js to 1.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ def scala211 = "2.11.12"
 def scala213 = "2.13.4"
 def scala3 = List("3.0.0-RC1", "3.0.0-M3", "3.0.0-M2")
 
-def scalajs = "1.3.0"
+def scalajs = "1.5.0"
 def scalajsBinaryVersion = "1"
 def scalajsDom = "1.1.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
 


### PR DESCRIPTION
I need to use my libraries that require Scala.js 1.5.0 from mdoc:js.

Currently I'm getting `org.scalajs.ir.IRVersionNotSupportedException: Failed to deserialize a file compiled with Scala.js 1.5 (supported up to: 1.3)` when I try to do this.

Bumping Scala.js version in mdoc seems to solve the issue (I looked at previous bump commits, and also checked locally with publishLocal).