### PR TITLE
Change default Scala version to 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ def crossSetting[A](
 
 inThisBuild(
   List(
-    scalaVersion := scala212,
+    scalaVersion := scala213,
     crossScalaVersions := scala2Versions ::: scala3,
     organization := "org.scalameta",
     licenses := Seq(


### PR DESCRIPTION
Previously, running `sbt test` would not work due to a missing cli dependency, which had the default 2.12 version. Now this will work properly and should be easier for users when experimenting with the workspace.