### PR TITLE
Allow usage of empty package

### DIFF
--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -42,6 +42,7 @@ class MarkdownCompiler(
   settings.unchecked.value = true // enable detailed unchecked warnings
   settings.outputDirs.setSingleOutput(target)
   settings.classpath.value = classpath
+  settings.exposeEmptyPackage.value = true
   // enable -Ydelambdafy:inline to avoid future timeouts, see:
   //   https://github.com/scala/bug/issues/9824
   //   https://github.com/scalameta/mdoc/issues/124

--- a/runtime/src/main/scala/mdoc/document/Binder.scala
+++ b/runtime/src/main/scala/mdoc/document/Binder.scala
@@ -10,7 +10,7 @@ final class Binder[T](val value: T, val name: String, val tpe: TPrint[T], val po
     s"""Binder($valueString, "$name", "$tpeString")"""
   }
 
-  def tpeString = Printing.typeString(tpe)
+  def tpeString = Printing.typeString(tpe).stripPrefix("<empty>.")
 }
 object Binder {
   def generate[A](e: SourceStatement[A], pos: RangePosition)(implicit


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/2363

This simplifies worksheets for users, since they can define separate classes in files and use in workspaces.