### PR TITLE
Make sure Scala 3 dialect is used when printing instrumented code

### DIFF
--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/FailInstrumenter.scala
@@ -38,7 +38,7 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
                       ) if Instrumenter.magicImports(name) =>
                   case importer =>
                     sb.print("import ")
-                    sb.print(importer.syntax)
+                    sb.print(importer.pos.text)
                     sb.print(";")
                 }
               case _ =>

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -103,7 +103,7 @@ class Instrumenter(
         case i: Import =>
           def printImporter(importer: Importer): Unit = {
             sb.print("import ")
-            sb.print(importer.syntax)
+            sb.print(importer.pos.text)
             sb.print(";")
           }
           i.importers.foreach {

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/FailInstrumenter.scala
@@ -39,7 +39,7 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
                   case importer =>
                     sb.line {
                       _.append("import ")
-                      .append(importer.syntax)
+                      .append(importer.pos.text)
                       .append(";")
                     }
                 }

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -100,7 +100,7 @@ class Instrumenter(
         case i: Import =>
           def printImporter(importer: Importer): Unit = {
               sb.line {_.append("import ")
-              .append(importer.syntax)
+              .append(importer.pos.text)
               .append(";")
             }
           }

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -51,6 +51,19 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
+  checkDecorations(
+    "import-future".tag(OnlyScala3),
+    """|import $scalac.`-source future`
+       |import scala.collection.*
+       |val x = 1.to(4).toVector
+       |""".stripMargin,
+    """|import $scalac.`-source future`
+       |import scala.collection.*
+       |<val x = 1.to(4).toVector> // : Vector[Int] = Vect...
+       |x: Vector[Int] = Vector(1, 2, 3, 4)
+       |""".stripMargin
+  )
+
   checkDiagnostics(
     "value-class",
     """|object Foo {


### PR DESCRIPTION
Previously, we would use the default dialect, which would print `import something._` instead of `import something.*` and this would break with the -source future flag that drops the former syntax.

Fixes https://github.com/scalameta/mdoc/issues/513