### PR TITLE
[Scala 3] Skip end markers when evaluating code

### DIFF
--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -91,6 +91,7 @@ class Instrumenter(
       val binders = stat match {
         case Binders(names) =>
           names.map(name => name -> name.pos)
+        case _ : Term.EndMarker => Nil
         case _ =>
           val fresh = gensym.fresh("res")
           sb.line{_.append(s"val $fresh = ")}
@@ -111,6 +112,7 @@ class Instrumenter(
             case importer =>
               printImporter(importer)
           }
+        case _ : Term.EndMarker => 
         case _ =>
           sb.appendLines(stat.pos.text)
       }

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -407,6 +407,24 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
+    "end-markers".tag(OnlyScala3),
+    """|
+       |def hello() =
+       |  println("This is a method")
+       |end hello
+       |
+       |hello()
+       |""".stripMargin,
+    """|def hello() =
+       |  println("This is a method")
+       |end hello
+       |
+       |<hello()> // This is a method
+       |// This is a method
+       |""".stripMargin
+  )
+
+  checkDecorations(
     "akka".tag(SkipScala3).tag(SkipScala211),
     """|import $dep.`com.typesafe.akka::akka-actor:2.6.13`
        |import akka.actor.ActorSystem


### PR DESCRIPTION
Related https://github.com/scalameta/metals/issues/2943