### PR TITLE
Make `node: HTMLElement` available as an implicit

### DIFF
--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -29,6 +29,7 @@ import org.scalajs.linker.MemOutputFile
 import java.util.concurrent.Executor
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalajs.linker.interface.ClearableLinker
+import scala.util.Random
 
 class JsModifier extends mdoc.PreModifier {
   override val name = "js"
@@ -140,6 +141,7 @@ class JsModifier extends mdoc.PreModifier {
     val code = new CodeBuilder()
     val wrapped = code
       .println("object mdocjs {")
+      .println(s"""class HTMLElementImplicit(val value: _root_.org.scalajs.dom.raw.HTMLElement)""")
       .foreach(runs)(code.println)
       .println("}")
       .toString
@@ -254,6 +256,7 @@ class JsModifier extends mdoc.PreModifier {
           .println(
             s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {"""
           )
+          .println(s"implicit val ${mountNodeParam}Implicit = new HTMLElementImplicit($mountNodeParam);")
           .println(input.text)
           .println("}")
           .toString

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -282,10 +282,14 @@ class JsSuite extends BaseMarkdownSuite {
       |println(jsdocs.ExampleJS.greeting)
       |```
     """.stripMargin,
-    """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
+    """|error: no-dom.md:3 (mdoc generated code) object scalajs is not a member of package org
+       |class HTMLElementImplicit(val value: _root_.org.scalajs.dom.raw.HTMLElement)
+       |                                                ^
+       |
+       |error: no-dom.md:5 (mdoc generated code) object scalajs is not a member of package org
        |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
        |                          ^
-    """.stripMargin,
+       |""".stripMargin,
     settings = {
       val noScalajsDom = Classpath(baseSettings.site("js-classpath")).entries
         .filterNot(_.toNIO.getFileName.toString.contains("scalajs-dom"))
@@ -376,5 +380,25 @@ class JsSuite extends BaseMarkdownSuite {
         site = baseSettings.site.updated("js-html-header", unpkgReact)
       )
     }
+  )
+
+  check(
+    "implicit-node",
+    """
+      |```scala mdoc:js:shared:invisible
+      |def div(msg: String)(implicit node: HTMLElementImplicit) =
+      |  node.value.innerHTML = "msg"
+      |```
+      |```scala mdoc:js
+      |div("hello world")
+      |```
+      |""".stripMargin,
+    """|```scala
+       |div("hello world")
+       |```
+       |<div id="mdoc-html-run1" data-mdoc-js></div>
+       |<script type="text/javascript" src="implicit-node.md.js" defer></script>
+       |<script type="text/javascript" src="mdoc.js" defer></script>
+       |""".stripMargin
   )
 }

--- a/tests/unit/src/main/scala/tests/markdown/BaseMarkdownSuite.scala
+++ b/tests/unit/src/main/scala/tests/markdown/BaseMarkdownSuite.scala
@@ -86,7 +86,7 @@ abstract class BaseMarkdownSuite extends tests.BaseSuite {
       original: String,
       settings: Settings = baseSettings,
       onOutput: String => Unit = _ => ()
-  ): Unit = {
+  )(implicit loc: munit.Location): Unit = {
     test(name) {
       val reporter = newReporter()
       val context = newContext(settings, reporter)


### PR DESCRIPTION
This makes it possible to implement helper methods that edit
`innerHTML`. Fixes #538.