### PR TITLE
Crash blocks are incorrectly indented when nesting

### DIFF
--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/CodePrinter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/CodePrinter.scala
@@ -9,11 +9,13 @@ class CodePrinter(ps: PrintStream, baseIndent: Int = 0, baseNest: Int = 0) {
 
   def append(s: String) = {ps.append(s); this }
   
-  def println(s: String) = {ps.print(indent + s + "\n"); this}
+  def println(s: String) = {
+    ps.print(indent + s + "\n"); this
+  }
 
   def definition(header: String)(cb: CodePrinter => Unit): CodePrinter = {
-    val newCB = new CodePrinter(ps, baseIndent + 1, baseNest)
-
+    val newCB = new CodePrinter(ps, baseIndent + 1, nestCount)
+    
     this.println(header + " {")
     cb(newCB)
     this.println("}")

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -78,7 +78,8 @@ class Instrumenter(
               }
             }
             
-            sb.println("\n$doc.endStatement();")
+            sb.println("\n") // newline for posterity
+            sb.println("$doc.endStatement();")
 
           case Nil =>
         }

--- a/tests/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/tests/src/main/scala/tests/BaseSuite.scala
@@ -16,10 +16,10 @@ class BaseSuite extends FunSuite {
       clue
     )
   }
-  
-  private def processOutput(raw: String) = 
+
+  private def processOutput(raw: String) =
     raw.replaceAll("\t", " ")
-  
+
   object OnlyScala213 extends munit.Tag("OnlyScala213")
   object OnlyScala3 extends munit.Tag("OnlyScala3")
   object SkipScala3 extends munit.Tag("SkipScala3")

--- a/tests/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/tests/src/main/scala/tests/BaseSuite.scala
@@ -11,11 +11,15 @@ class BaseSuite extends FunSuite {
       loc: Location
   ): Unit = {
     super.assertNoDiff(
-      Compat(obtained, Map.empty, postProcessObtained),
-      Compat(expected, Map.empty, postProcessExpected),
+      Compat(processOutput(obtained), Map.empty, postProcessObtained),
+      Compat(processOutput(expected), Map.empty, postProcessExpected),
       clue
     )
   }
+  
+  private def processOutput(raw: String) = 
+    raw.replaceAll("\t", " ")
+  
   object OnlyScala213 extends munit.Tag("OnlyScala213")
   object OnlyScala3 extends munit.Tag("OnlyScala3")
   object SkipScala3 extends munit.Tag("SkipScala3")

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -236,21 +236,39 @@ class CrashSuite extends BaseMarkdownSuite {
     )
   )
 
-  check("significant-indentation".tag(OnlyScala3),
+  check(
+    "significant-indentation".tag(OnlyScala3),
     """
-    |```scala mdoc:nest
-    |println("what!")
-    |```
-    |
-    |```scala mdoc:crash
-    |def hello(x: Int) = 
-    |  if x != 0 then
-    |    println(x)
-    |    x / 0
-    |hello(5)
-    |```
-    |""".stripMargin,
-    ""
+      |```scala mdoc:nest
+      |println("what!")
+      |```
+      |
+      |```scala mdoc:crash
+      |def hello(x: Int) =
+      |  if x != 0 then
+      |    println(x)
+      |    x / 0
+      |hello(5)
+      |```
+      |""".stripMargin,
+      """
+      |```scala
+      |println("what!")
+      |// what!
+      |```
+      |
+      |```scala
+      |def hello(x: Int) =
+      |  if x != 0 then
+      |    println(x)
+      |    x / 0
+      |hello(5)
+      |// java.lang.ArithmeticException: / by zero
+      |//  at repl.MdocSession$App.hello$1(significant-indentation.md:19)
+      |//  at repl.MdocSession$App.$init$$$anonfun$1(significant-indentation.md:20)
+      |//  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
+      |```""".stripMargin
+
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -236,6 +236,23 @@ class CrashSuite extends BaseMarkdownSuite {
     )
   )
 
+  check("significant-indentation".tag(OnlyScala3),
+    """
+    |```scala mdoc:nest
+    |println("what!")
+    |```
+    |
+    |```scala mdoc:crash
+    |def hello(x: Int) = 
+    |  if x != 0 then
+    |    println(x)
+    |    x / 0
+    |hello(5)
+    |```
+    |""".stripMargin,
+    ""
+  )
+
   check(
     "multiple-statements",
     """

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -251,7 +251,7 @@ class CrashSuite extends BaseMarkdownSuite {
       |hello(5)
       |```
       |""".stripMargin,
-      """
+    """
       |```scala
       |println("what!")
       |// what!
@@ -268,7 +268,6 @@ class CrashSuite extends BaseMarkdownSuite {
       |//  at repl.MdocSession$App.$init$$$anonfun$1(significant-indentation.md:20)
       |//  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
       |```""".stripMargin
-
   )
 
   check(


### PR DESCRIPTION
Reproduces and fixes #552.

I introduced this regression in #551. There's actually two bugs in here - 
- incorrectly passing the indentation level to the code inside definition and
- undoing the indentation-aware codeprinter's work by adding a newline myself 🤦 