### PR TITLE
[Scala 3] Fix indentation in generated code

### DIFF
--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/CodePrinter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/CodePrinter.scala
@@ -23,8 +23,10 @@ class CodePrinter(ps: PrintStream, baseIndent: Int = 0, baseNest: Int = 0) {
     this
   }
 
-  def appendLines(body: String) = {
+  def appendLines(body: String, nest: Boolean = false) = {
+    if (nest) nestCount += 1
     body.linesIterator.toArray.foreach(this.println)
+    if(nest) nestCount -= 1
     this
   }
 

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -332,4 +332,19 @@ class DefaultSuite extends BaseMarkdownSuite {
        |""".stripMargin
   )
 
+  check(
+    "infix",
+    """
+      |```scala mdoc
+      |import scala.language.postfixOps
+      |42 toString
+      |```
+    """.stripMargin,
+    """|```scala
+       |import scala.language.postfixOps
+       |42 toString
+       |// res0: String = "42"
+       |```
+       |""".stripMargin
+  )
 }

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -52,6 +52,24 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
+    "infix",
+    """|import scala.language.postfixOps
+       |42 toString
+       |""".stripMargin,
+    """|import scala.language.postfixOps
+       |<42 toString> // : String = "42"
+       |res0: String = "42"
+       |""".stripMargin,
+    compat = Map(
+      Compat.Scala3 ->
+        """|import scala.language.postfixOps
+           |<42 toString> // : String = 42
+           |res0: String = 42
+           |""".stripMargin
+    )
+  )
+
+  checkDecorations(
     "null",
     """
       |val x: String = null


### PR DESCRIPTION
Previously, we would not add an additional nesting for expressions with generated defintion, which could cause the binder statement to be included in the evaluated statement.

Now, we correctly indent after `=` for generated definitions.

Fixes https://github.com/scalameta/mdoc/issues/565