### PR TITLE
Add Scala 3.1.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - "'++2.12.12 test'"
           - "'++2.12.14 test' scripted"
           - "'++2.13.6 test'"
-          - "'++3.0.1 test'"
+          - "'++3.1.0 test'"
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ out/
 .bloop/
 metals.sbt
 .vscode/
+.bsp
 
 website/translated_docs
 website/build/

--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,11 @@ import scala.collection.mutable
 def scala212 = "2.12.15"
 def scala211 = "2.11.12"
 def scala213 = "2.13.6"
-def scala3 = "3.0.2"
+def scala3 = "3.1.0"
 def scala2Versions = List(scala212, scala211, scala213)
 def allScalaVersions = scala2Versions :+ scala3
 
-def scalajs = "1.5.1"
+def scalajs = "1.7.1"
 def scalajsBinaryVersion = "1"
 def scalajsDom = "1.1.0"
 

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))
 addSbtCoursier

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/MarkdownCompiler.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/MarkdownCompiler.scala
@@ -124,7 +124,7 @@ class MarkdownCompiler(
     report(vreporter, input, fileImports, run.runContext, edit)
   }
 
-  class CollectionReporter extends dotty.tools.dotc.reporting.Reporter {
+  class CollectionReporter extends dotty.tools.dotc.reporting.Reporter with UniqueMessagePositions {
     val allDiags = List.newBuilder[Diagnostic]
 
     override def doReport(dia: Diagnostic)(using Context) = 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 
 libraryDependencies ++= List(

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -300,14 +300,6 @@ class JsSuite extends BaseMarkdownSuite {
           |no-dom.md:3 (mdoc generated code)
           | value scalajs is not a member of org
           |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
-          |
-          |
-          |error:
-          |no-dom.md:3 (mdoc generated code)
-          | (<error value scalajs is not a member of org>#dom.raw :
-          |  <error value scalajs is not a member of org>
-          |) is not a valid type prefix, since it is not an immutable path
-          |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
       """.stripMargin
     )
   )


### PR DESCRIPTION
~Notes: scala3 artifacts are published with `_$major.$minor` postfix~
After a discussion we decided just to upgrade scala 3 version