### PR TITLE
Update to scala-js-dom 2.0.0, take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ def allScalaVersions = scala2Versions :+ scala3
 
 def scalajs = "1.7.1"
 def scalajsBinaryVersion = "1"
-def scalajsDom = "1.1.0"
+def scalajsDom = "2.0.0"
 
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 def isScala212(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2) && v.exists(_._2 == 12)
@@ -278,7 +278,7 @@ val jsdocs = project
       _.withModuleKind(ModuleKind.CommonJSModule)
     },
     libraryDependencies ++= List(
-      "org.scala-js" %%% "scalajs-dom" % scalajsDom cross CrossVersion.for3Use2_13
+      "org.scala-js" %%% "scalajs-dom" % scalajsDom
     ),
     scalaJSUseMainModuleInitializer := true,
     Compile / npmDependencies ++= List(

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -252,7 +252,7 @@ class JsModifier extends mdoc.PreModifier {
         new CodeBuilder()
           .println(s"""@_root_.scala.scalajs.js.annotation.JSExportTopLevel("$jsId") """)
           .println(
-            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {"""
+            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.HTMLElement): Unit = {"""
           )
           .println(input.text)
           .println("}")

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -252,7 +252,7 @@ class JsModifier extends mdoc.PreModifier {
         new CodeBuilder()
           .println(s"""@_root_.scala.scalajs.js.annotation.JSExportTopLevel("$jsId") """)
           .println(
-            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {"""
+            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.html.Element): Unit = {"""
           )
           .println(input.text)
           .println("}")

--- a/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
+++ b/mdoc-js/src/main/scala/mdoc/modifiers/JsModifier.scala
@@ -252,7 +252,7 @@ class JsModifier extends mdoc.PreModifier {
         new CodeBuilder()
           .println(s"""@_root_.scala.scalajs.js.annotation.JSExportTopLevel("$jsId") """)
           .println(
-            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.HTMLElement): Unit = {"""
+            s"""def $run($mountNodeParam: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {"""
           )
           .println(input.text)
           .println("}")

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -28,6 +28,6 @@ println("Hello Scala.js!")
 
 lazy val jsapp = project
   .settings(
-    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0"
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.0.0"
   )
   .enablePlugins(ScalaJSPlugin)

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -269,7 +269,7 @@ class JsSuite extends BaseMarkdownSuite {
     "onclick",
     """
       |```scala mdoc:js
-      |import org.scalajs.dom.raw.MouseEvent
+      |import org.scalajs.dom.MouseEvent
       |node.onclick = {(_: MouseEvent) => println(42)}
       |```
     """.stripMargin
@@ -283,7 +283,7 @@ class JsSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
-       |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
+       |def run0(node: _root_.org.scalajs.dom.html.Element): Unit = {
        |                          ^
     """.stripMargin,
     settings = {
@@ -299,7 +299,7 @@ class JsSuite extends BaseMarkdownSuite {
           |error:
           |no-dom.md:3 (mdoc generated code)
           | value scalajs is not a member of org
-          |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
+          |def run0(node: _root_.org.scalajs.dom.html.Element): Unit = {
       """.stripMargin
     )
   )

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -269,7 +269,7 @@ class JsSuite extends BaseMarkdownSuite {
     "onclick",
     """
       |```scala mdoc:js
-      |import org.scalajs.dom.MouseEvent
+      |import org.scalajs.dom.raw.MouseEvent
       |node.onclick = {(_: MouseEvent) => println(42)}
       |```
     """.stripMargin
@@ -283,7 +283,7 @@ class JsSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
-       |def run0(node: _root_.org.scalajs.dom.HTMLElement): Unit = {
+       |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
        |                          ^
     """.stripMargin,
     settings = {
@@ -299,7 +299,7 @@ class JsSuite extends BaseMarkdownSuite {
           |error:
           |no-dom.md:3 (mdoc generated code)
           | value scalajs is not a member of org
-          |def run0(node: _root_.org.scalajs.dom.HTMLElement): Unit = {
+          |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
       """.stripMargin
     )
   )

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -269,7 +269,7 @@ class JsSuite extends BaseMarkdownSuite {
     "onclick",
     """
       |```scala mdoc:js
-      |import org.scalajs.dom.raw.MouseEvent
+      |import org.scalajs.dom.MouseEvent
       |node.onclick = {(_: MouseEvent) => println(42)}
       |```
     """.stripMargin
@@ -283,7 +283,7 @@ class JsSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
-       |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
+       |def run0(node: _root_.org.scalajs.dom.HTMLElement): Unit = {
        |                          ^
     """.stripMargin,
     settings = {
@@ -299,7 +299,7 @@ class JsSuite extends BaseMarkdownSuite {
           |error:
           |no-dom.md:3 (mdoc generated code)
           | value scalajs is not a member of org
-          |def run0(node: _root_.org.scalajs.dom.raw.HTMLElement): Unit = {
+          |def run0(node: _root_.org.scalajs.dom.HTMLElement): Unit = {
       """.stripMargin
     )
   )


### PR DESCRIPTION
Like #575, except I turned on my brain and found a common set of sjs-dom aliases that exist and are _not_ deprecated on both SJS v1 and SJS v2. So no warnings for anyone.

Apologies to @keynmol 😅 for his efforts in #575.