### PR TITLE
[Scala3] Keep scala3-library in classpath

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownBuilder.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownBuilder.scala
@@ -85,6 +85,7 @@ object MarkdownBuilder {
         val runtime = defaultClasspath(path => {
           val pathString = path.toString
           pathString.contains("scala-library") ||
+          pathString.contains("scala3-library") ||
           pathString.contains("scala-reflect") ||
           pathString.contains("fansi") ||
           pathString.contains("pprint") ||


### PR DESCRIPTION
Probably should finally fix #525 

At least now it works in the case that  @keynmol described in [this comment](https://github.com/scalameta/mdoc/issues/525#issuecomment-923654577):
`java -cp $(cs fetch -p org.scalameta:mdoc_3:$LOCAL_SNAPSHOT) mdoc.Main --in test.md`