### PR TITLE
Check more scalaVersions in sbt scripted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,10 @@ jobs:
           - "'++2.11.12 test'"
           # Test legacy Scala versions, where reporting API changed
           - "'++2.12.12 test'"
-          - "'++2.12.14 test' scripted"
+          - "'++2.12.14 test'"
           - "'++2.13.6 test'"
           - "'++3.1.0 test'"
+          - "scripted"
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,11 +1,14 @@
-scalaVersion.in(ThisBuild) := "2.12.15"
+ThisBuild / scalaVersion := "2.12.15"
+ThisBuild / crossScalaVersions := List("2.12.15", "2.13.6", "3.0.1")
 
 enablePlugins(MdocPlugin)
 mdocJS := Some(jsapp)
 
 TaskKey[Unit]("check") := {
-  val obtained = IO.read(mdocOut.value / "readme.md")
-  println()
+  val file = mdocOut.value / "readme.md"
+  val obtained = IO.read(file)
+  IO.delete(file)
+  println(s"----${scalaVersion.value}----")
   println(obtained)
   println()
   assert(
@@ -24,10 +27,16 @@ println("Hello Scala.js!")
 """.trim,
     "\"\"\"\n" + obtained + "\n\"\"\""
   )
+  println("------------------")
 }
 
 lazy val jsapp = project
   .settings(
-    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0"
+    libraryDependencies += {
+      if (scalaVersion.value.startsWith("3"))
+        "org.scala-js" %%% "scalajs-dom" % "1.1.0" cross CrossVersion.for3Use2_13
+      else
+        "org.scala-js" %%% "scalajs-dom" % "1.1.0"
+    }
   )
   .enablePlugins(ScalaJSPlugin)

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))
-addSbtCoursier

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
@@ -1,4 +1,8 @@
-> mdoc
+> ++2.12.15 mdoc
 > check
-> set mdocIn := baseDirectory.in(ThisBuild).value
+> ++2.13.6 mdoc
+> check
+> ++3.1.0 mdoc
+> check
+> set mdocIn := (ThisBuild / baseDirectory).value
 -> mdoc


### PR DESCRIPTION
Notice, I've tried to add `3.0.2` too but `js` modifier doesn't work after switching on 3.1.0.
It seems that the reason is that 3.1.0 compiles into 1.7 scala-js IR while 3.0 support only 1.5.*.

The only way to fix that is to change publishing scheme as it was discussed in [prev pr](https://github.com/scalameta/mdoc/pull/568#discussion_r732134138)
I don't know if it's critical or if we could leave it as it is at least for a while.