### PR TITLE
Drop Scala 2.11 support and update pprint/fnase/metaconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
-      - run: sbt '++2.12.14 docs/mdoc'
+      - run: sbt '++2.12.15 docs/mdoc'
   test-windows:
     name: "Windows"
     runs-on: windows-latest
@@ -39,10 +39,9 @@ jobs:
       matrix:
         java: [adopt@1.8, adopt@1.11, 17]
         command:
-          - "'++2.11.12 test'"
           # Test legacy Scala versions, where reporting API changed
           - "'++2.12.12 test'"
-          - "'++2.12.14 test'"
+          - "'++2.12.15 test'"
           - "'++2.13.8 test'"
           - "'++3.1.0 test'"
           - "scripted"

--- a/.github/workflows/mdoc.yml
+++ b/.github/workflows/mdoc.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
-      - run: sbt '++2.12.14 docs/docusaurusPublishGhpages'
+      - run: sbt '++2.12.15 docs/docusaurusPublishGhpages'
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
       - name: Check git diff

--- a/cli/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/cli/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -31,6 +31,7 @@ import mdoc.Reporter
 import mdoc.internal.markdown.{GitHubIdGenerator, ReplVariablePrinter}
 import mdoc.internal.cli.CliEnrichments._
 import pprint.TPrint
+import pprint.TPrintColors
 
 class Section(val name: String) extends StaticAnnotation
 
@@ -300,13 +301,24 @@ object Settings { // extends MetaconfigScalametaImplicits with Decoders with Set
   def write(set: Settings) = ConfEncoder[Settings].write(set)
 
   implicit val absolutePathPrint: TPrint[AbsolutePath] =
-    TPrint.make[AbsolutePath](_ => "<path>")
+    new TPrint[AbsolutePath] {
+      def render(implicit tpc: TPrintColors): fansi.Str = fansi.Str("<path>")
+    }
+
   implicit val pathMatcherPrint: TPrint[PathMatcher] =
-    TPrint.make[PathMatcher](_ => "<glob>")
+    new TPrint[PathMatcher] {
+      def render(implicit tpc: TPrintColors): fansi.Str = fansi.Str("<glob>")
+    }
+
   implicit def optionPrint[T](implicit ev: pprint.TPrint[T]): TPrint[Option[T]] =
-    TPrint.make { implicit cfg => ev.render }
+    new TPrint[Option[T]] {
+      def render(implicit tpc: TPrintColors): fansi.Str = ev.render
+    }
+
   implicit def iterablePrint[C[x] <: Iterable[x], T](implicit ev: pprint.TPrint[T]): TPrint[C[T]] =
-    TPrint.make { implicit cfg => s"[${ev.render} ...]" }
+    new TPrint[C[T]] {
+      def render(implicit tpc: TPrintColors): fansi.Str = s"[${ev.render} ...]"
+    }
 
   implicit val pathMatcherDecoder: ConfDecoder[PathMatcher] =
     ConfDecoder.stringConfDecoder.map(glob => FileSystems.getDefault.getPathMatcher("glob:" + glob))

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Processor.scala
@@ -17,9 +17,9 @@ import scala.meta.dialects.{Scala213, Scala3}
 import scala.util.control.NonFatal
 import mdoc.internal.cli.Context
 import mdoc.internal.document.MdocExceptions
+import mdoc.internal.document.Printing
 import mdoc.internal.markdown.Modifier._
 import mdoc.internal.pos.PositionSyntax._
-import pprint.TPrintColors
 import scala.meta.io.RelativePath
 import coursierapi.error.SimpleResolutionError
 import coursierapi.error.CoursierError
@@ -198,7 +198,6 @@ class Processor(implicit ctx: Context) {
           ctx.settings.variablePrinter,
           markdownCompiler
         )
-      implicit val pprintColor = TPrintColors.BlackWhite
       mod match {
         case Modifier.Post(modifier, info) =>
           val variables = for {
@@ -209,7 +208,7 @@ class Processor(implicit ctx: Context) {
           } yield {
             new mdoc.Variable(
               binder.name,
-              binder.tpe.render,
+              Printing.typeString(binder.tpe),
               binder.value,
               binder.pos.toMeta(section),
               j,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -10,6 +10,7 @@ import mdoc.document.CrashResult.Crashed
 import mdoc.document.RangePosition
 import mdoc.internal.document.FailSection
 import mdoc.internal.document.MdocExceptions
+import mdoc.internal.document.Printing
 import mdoc.internal.pos.PositionSyntax._
 import mdoc.internal.pos.TokenEditDistance
 import scala.meta._
@@ -157,7 +158,7 @@ object Renderer {
                   }
                   appendFreshMultiline(sb, compiled)
                 case _ =>
-                  val obtained = pprint.PPrinter.BlackWhite.apply(binder).toString()
+                  val obtained = Printing.stringValue(binder.value)
                   throw new IllegalArgumentException(
                     s"Expected FailSection. Obtained $obtained"
                   )
@@ -166,7 +167,7 @@ object Renderer {
               val pos = binder.pos.toMeta(section)
               val variable = new mdoc.Variable(
                 binder.name,
-                binder.tpe.render,
+                Printing.typeString(binder.tpe),
                 binder.value,
                 pos,
                 i,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ libraryDependencies ++= List(
   "org.jsoup" % "jsoup" % "1.12.1",
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 )
-unmanagedSourceDirectories.in(Compile) +=
-  baseDirectory.in(ThisBuild).value.getParentFile /
+Compile / unmanagedSourceDirectories +=
+  (ThisBuild / baseDirectory).value.getParentFile /
     "mdoc-sbt" / "src" / "main" / "scala"

--- a/runtime/src/main/scala-2/mdoc/internal/document/Printing.scala
+++ b/runtime/src/main/scala-2/mdoc/internal/document/Printing.scala
@@ -8,7 +8,7 @@ import Compat.TPrint
 object Printing {
 
   def stringValue[T](value: T) = PPrinter.BlackWhite.apply(value)
-  def typeString[T](tprint: TPrint[T]) = tprint.render(TPrintColors.BlackWhite)
+  def typeString[T](tprint: TPrint[T]): String = tprint.render(TPrintColors.BlackWhite).render
   def print[T](value: T, out: StringBuilder, width: Int, height: Int) = {
     BlackWhite
       .tokenize(value, width, height)

--- a/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/cli/ScalacOptionsSuite.scala
@@ -200,7 +200,7 @@ class ScalacOptionsSuite extends BaseCliSuite {
            |final case class Test(value: Int)
            |
            |val test = Test(123)
-           |// test: Test = Test(123)
+           |// test: Test = Test(value = 123)
            |
            |test.value
            |// res0: Int = 123

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -146,6 +146,13 @@ class DefaultSuite extends BaseMarkdownSuite {
            |User("John", 42)
            |// res0: User = User(name = "John", age = 42)
            |```
+           |""".stripMargin,
+      Compat.Scala3 ->
+        """|```scala
+           |case class User(name: String, age: Int)
+           |User("John", 42)
+           |// res0: User = User(name = "John", age = 42)
+           |```
            |""".stripMargin
     )
   )

--- a/tests/unit/src/test/scala/tests/markdown/SemanticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/SemanticsSuite.scala
@@ -41,6 +41,16 @@ class SemanticsSuite extends BaseMarkdownSuite {
        |```
     """.stripMargin,
     compat = Map(
+      Compat.Scala3 ->
+        """|```scala
+           |case class User(name: String)
+           |object User {
+           |  implicit val ordering: Ordering[User] = Ordering.by(_.name)
+           |}
+           |List(User("Susan"), User("John")).sorted
+           |// res0: List[User] = List(User(name = "John"), User(name = "Susan"))
+           |```
+           |""".stripMargin,
       Compat.Scala213 ->
         """|```scala
            |case class User(name: String)


### PR DESCRIPTION
Fixes https://github.com/scalameta/mdoc/issues/602

It seem there were a lot of changes in pprint:
https://github.com/com-lihaoyi/PPrint/commit/7fead8de53cc0e1679fb649f3f1d89dee1754185#diff-492a668d78a78a50945e22826d563419a9c827b6164bca4bfedb3a7c4f66d551

~~It seems we need t first bump this in metaconfig.~~ it's updated, but metaconfig no longer publishes for 2.11, so we need to drop it in mdoc also, which I think is not an issue, since people can stay with older versions for now. Opinions?
