### PR TITLE
Renamed MdocSession.App to MdocSession.MdocApp

### DIFF
--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/FailInstrumenter.scala
@@ -16,14 +16,14 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private def printAsScript(): Unit = {
     sb.println("package repl")
     sb.println("object MdocSession {")
-    sb.println("  object App {")
+    sb.println("  object MdocApp {")
 
     sections.zipWithIndex.foreach { case (section, j) =>
       if (j > i) ()
       else {
         if (section.mod.isReset) {
           nest.unnest()
-          sb.print(Instrumenter.reset(section.mod, gensym.fresh("App")))
+          sb.print(Instrumenter.reset(section.mod, gensym.fresh("MdocApp")))
         } else if (section.mod.isNest) {
           nest.nest()
         }

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -41,7 +41,7 @@ class Instrumenter(
     sections.zipWithIndex.foreach { case (section, i) =>
       if (section.mod.isReset) {
         nest.unnest()
-        sb.print(Instrumenter.reset(section.mod, gensym.fresh("App")))
+        sb.print(Instrumenter.reset(section.mod, gensym.fresh("MdocApp")))
       } else if (section.mod.isNest) {
         nest.nest()
       }
@@ -175,8 +175,8 @@ object Instrumenter {
     val wrapped = new StringBuilder()
       .append("package repl\n")
       .append("object MdocSession extends _root_.mdoc.internal.document.DocumentBuilder {\n")
-      .append("  def app(): _root_.scala.Unit = {val _ = new App()}\n")
-      .append("  class App {\n")
+      .append("  def app(): _root_.scala.Unit = {val _ = new MdocApp()}\n")
+      .append("  class MdocApp {\n")
       .append(body)
       .append("  }\n")
       .append("}\n")

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/FailInstrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/FailInstrumenter.scala
@@ -16,14 +16,14 @@ final class FailInstrumenter(sections: List[SectionInput], i: Int) {
   private def printAsScript(): Unit = {
     snip.println("package repl")
     snip.definition("object MdocSession") {
-      _.definition("object App") { sb =>
+      _.definition("object MdocApp") { sb =>
 
         sections.zipWithIndex.foreach { case (section, j) =>
           if (j > i) ()
           else {
             if (section.mod.isReset) {
               sb.unnest()
-              sb.append(Instrumenter.reset(section.mod, gensym.fresh("App")))
+              sb.append(Instrumenter.reset(section.mod, gensym.fresh("MdocApp")))
             } else if (section.mod.isNest) {
               sb.nest()
             }

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -39,7 +39,7 @@ class Instrumenter(
     sections.zipWithIndex.foreach { case (section, i) =>
       if (section.mod.isReset) {
         sb.unnest()
-        sb.println(Instrumenter.reset(section.mod, gensym.fresh("App")))
+        sb.println(Instrumenter.reset(section.mod, gensym.fresh("MdocApp")))
       } else if (section.mod.isNest) {
         sb.nest()
       }
@@ -179,8 +179,8 @@ object Instrumenter {
     val cb = new CodePrinter(ps)
     cb.println("package repl")
     cb.definition("object MdocSession extends _root_.mdoc.internal.document.DocumentBuilder") {
-      _.println("def app(): _root_.scala.Unit = {val _ = new App()}")
-        .definition("class App") {
+      _.println("def app(): _root_.scala.Unit = {val _ = new MdocApp()}")
+        .definition("class MdocApp") {
           _.appendLines(body)
         }
 

--- a/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/AsyncSuite.scala
@@ -34,7 +34,7 @@ class AsyncSuite extends BaseMarkdownSuite {
        |	at scala.concurrent.Await$.$anonfun$result$1(package.scala:223)
        |	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:57)
        |	at scala.concurrent.Await$.result(package.scala:146)
-       |	at repl.MdocSession$App.<init>(timeout.md:11)
+       |	at repl.MdocSession$MdocApp.<init>(timeout.md:11)
        |	at repl.MdocSession$.app(timeout.md:3)
        |""".stripMargin,
     compat = Map(
@@ -48,7 +48,7 @@ class AsyncSuite extends BaseMarkdownSuite {
            |	at scala.concurrent.Await$$anonfun$result$1.apply(package.scala:190)
            |	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
            |	at scala.concurrent.Await$.result(package.scala:190)
-           |	at repl.MdocSession$App.<init>(timeout.md:11)
+           |	at repl.MdocSession$MdocApp.<init>(timeout.md:11)
            |	at repl.MdocSession$.app(timeout.md:3)
            |""".stripMargin,
       Compat.Scala213 ->
@@ -61,7 +61,7 @@ class AsyncSuite extends BaseMarkdownSuite {
            |	at scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
            |	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
            |	at scala.concurrent.Await$.result(package.scala:124)
-           |	at repl.MdocSession$App.<init>(timeout.md:11)
+           |	at repl.MdocSession$MdocApp.<init>(timeout.md:11)
            |	at repl.MdocSession$.app(timeout.md:3)
            |""".stripMargin,
       Compat.Scala3 ->
@@ -74,7 +74,7 @@ class AsyncSuite extends BaseMarkdownSuite {
            |	at scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
            |	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
            |	at scala.concurrent.Await$.result(package.scala:124)
-           |	at repl.MdocSession$App.<init>(timeout.md:13)
+           |	at repl.MdocSession$MdocApp.<init>(timeout.md:13)
            |	at repl.MdocSession$.app(timeout.md:3)
            |""".stripMargin
     )

--- a/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CrashSuite.scala
@@ -14,8 +14,8 @@ class CrashSuite extends BaseMarkdownSuite {
        |???
        |// scala.NotImplementedError: an implementation is missing
        |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(basic.md:10)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(basic.md:8)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(basic.md:10)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(basic.md:8)
        |```
     """.stripMargin,
     compat = Map(
@@ -25,8 +25,8 @@ class CrashSuite extends BaseMarkdownSuite {
            |???
            |// scala.NotImplementedError: an implementation is missing
            |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:347)
-           |// 	at repl.MdocSession$App$$anonfun$1.apply(basic.md:10)
-           |// 	at repl.MdocSession$App$$anonfun$1.apply(basic.md:8)
+           |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(basic.md:10)
+           |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(basic.md:8)
            |```
     """.stripMargin,
       Compat.Scala3 ->
@@ -35,7 +35,7 @@ class CrashSuite extends BaseMarkdownSuite {
            |???
            |// scala.NotImplementedError: an implementation is missing
            |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:347)
-           |// 	at repl.MdocSession$App.$init$$anonfun$3(basic.md:14)
+           |// 	at repl.MdocSession$MdocApp.$init$$anonfun$3(basic.md:14)
            |```
     """.stripMargin
     )
@@ -83,7 +83,7 @@ class CrashSuite extends BaseMarkdownSuite {
        |  case 2 => // boom!
        |}
        |// scala.MatchError: 1 (of class java.lang.Integer)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(comments.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(comments.md:9)
        |```
     """.stripMargin,
     compat = Map(
@@ -93,7 +93,7 @@ class CrashSuite extends BaseMarkdownSuite {
            |  case 2 => // boom!
            |}
            |// scala.MatchError: 1 (of class java.lang.Integer)
-           |// 	at repl.MdocSession$App.$init$$anonfun$1(comments.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$anonfun$1(comments.md:9)
            |//  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
            |```
     """.stripMargin
@@ -111,8 +111,8 @@ class CrashSuite extends BaseMarkdownSuite {
        |???
        |// scala.NotImplementedError: an implementation is missing
        |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(relative.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(relative.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(relative.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(relative.md:9)
        |```
     """.stripMargin,
     compat = Map(
@@ -121,8 +121,8 @@ class CrashSuite extends BaseMarkdownSuite {
            |???
            |// scala.NotImplementedError: an implementation is missing
            |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:347)
-           |// 	at repl.MdocSession$App$$anonfun$1.apply(relative.md:9)
-           |// 	at repl.MdocSession$App$$anonfun$1.apply(relative.md:9)
+           |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(relative.md:9)
+           |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(relative.md:9)
            |```
     """.stripMargin,
       Compat.Scala3 ->
@@ -130,7 +130,7 @@ class CrashSuite extends BaseMarkdownSuite {
            |???
            |// scala.NotImplementedError: an implementation is missing
            |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:347)
-           |// 	at repl.MdocSession$App.$init$$anonfun$1(relative.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$anonfun$1(relative.md:9)
            |```
     """.stripMargin
     )
@@ -146,8 +146,8 @@ class CrashSuite extends BaseMarkdownSuite {
     """|```scala
        |throw new StackOverflowError()
        |// java.lang.StackOverflowError
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal.md:9)
        |```
        |""".stripMargin,
     compat = Map(
@@ -155,7 +155,7 @@ class CrashSuite extends BaseMarkdownSuite {
         """|```scala
            |throw new StackOverflowError()
            |// java.lang.StackOverflowError
-           |// 	at repl.MdocSession$App.$init$$$anonfun$1(fatal.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$$anonfun$1(fatal.md:9)
            |```
            |""".stripMargin
     )
@@ -171,8 +171,8 @@ class CrashSuite extends BaseMarkdownSuite {
     """|```scala
        |throw new NoClassDefFoundError()
        |// java.lang.NoClassDefFoundError
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal2.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal2.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal2.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal2.md:9)
        |```
        |""".stripMargin,
     compat = Map(
@@ -180,7 +180,7 @@ class CrashSuite extends BaseMarkdownSuite {
         """|```scala
            |throw new NoClassDefFoundError()
            |// java.lang.NoClassDefFoundError
-           |// 	at repl.MdocSession$App.$init$$$anonfun$1(fatal2.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$$anonfun$1(fatal2.md:9)
            |```
            |""".stripMargin
     )
@@ -196,8 +196,8 @@ class CrashSuite extends BaseMarkdownSuite {
     """|```scala
        |throw new NoSuchMethodError()
        |// java.lang.NoSuchMethodError
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal3.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal3.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal3.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal3.md:9)
        |```
        |""".stripMargin,
     compat = Map(
@@ -205,7 +205,7 @@ class CrashSuite extends BaseMarkdownSuite {
         """|```scala
            |throw new NoSuchMethodError()
            |// java.lang.NoSuchMethodError
-           |// 	at repl.MdocSession$App.$init$$$anonfun$1(fatal3.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$$anonfun$1(fatal3.md:9)
            |```
            |""".stripMargin
     )
@@ -221,8 +221,8 @@ class CrashSuite extends BaseMarkdownSuite {
     """|```scala
        |throw new IncompatibleClassChangeError()
        |// java.lang.IncompatibleClassChangeError
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal4.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(fatal4.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal4.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(fatal4.md:9)
        |```
        |""".stripMargin,
     compat = Map(
@@ -230,7 +230,7 @@ class CrashSuite extends BaseMarkdownSuite {
         """|```scala
            |throw new IncompatibleClassChangeError()
            |// java.lang.IncompatibleClassChangeError
-           |// 	at repl.MdocSession$App.$init$$$anonfun$1(fatal4.md:9)
+           |// 	at repl.MdocSession$MdocApp.$init$$$anonfun$1(fatal4.md:9)
            |```
            |""".stripMargin
     )
@@ -264,8 +264,8 @@ class CrashSuite extends BaseMarkdownSuite {
       |    x / 0
       |hello(5)
       |// java.lang.ArithmeticException: / by zero
-      |//  at repl.MdocSession$App.hello$1(significant-indentation.md:19)
-      |//  at repl.MdocSession$App.$init$$$anonfun$1(significant-indentation.md:20)
+      |//  at repl.MdocSession$MdocApp.hello$1(significant-indentation.md:19)
+      |//  at repl.MdocSession$MdocApp.$init$$$anonfun$1(significant-indentation.md:20)
       |//  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
       |```""".stripMargin
   )
@@ -283,9 +283,9 @@ class CrashSuite extends BaseMarkdownSuite {
        |(new Cat).func
        |// scala.NotImplementedError: an implementation is missing
        |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
-       |// 	at repl.MdocSession$App$$anonfun$1$Cat$1.func(multiple-statements.md:9)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:10)
-       |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:8)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1$Cat$1.func(multiple-statements.md:9)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:10)
+       |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:8)
        |```
       """.stripMargin,
     compat = Map(
@@ -294,27 +294,27 @@ class CrashSuite extends BaseMarkdownSuite {
                             |(new Cat).func
                             |// scala.NotImplementedError: an implementation is missing
                             |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
-                            |// 	at repl.MdocSession$App$$anonfun$1$Cat$1.func(multiple-statements.md:9)
-                            |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:10)
-                            |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:8)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1$Cat$1.func(multiple-statements.md:9)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:10)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:8)
                             |```""".stripMargin,
       Compat.Scala211 -> """|```scala
                             |class Cat { def func = ??? }
                             |(new Cat).func
                             |// scala.NotImplementedError: an implementation is missing
                             |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:230)
-                            |// 	at repl.MdocSession$App$$anonfun$1$Cat$1.func(multiple-statements.md:9)
-                            |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:10)
-                            |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:8)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1$Cat$1.func(multiple-statements.md:9)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:10)
+                            |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:8)
                             |```""".stripMargin,
       Compat.Scala3 -> """|```scala
                           |class Cat { def func = ??? }
                           |(new Cat).func
                           |// scala.NotImplementedError: an implementation is missing
                           |// 	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
-                          |// 	at repl.MdocSession$App$$anonfun$1$Cat$1.func(multiple-statements.md:9)
-                          |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:10)
-                          |// 	at repl.MdocSession$App$$anonfun$1.apply(multiple-statements.md:8)
+                          |// 	at repl.MdocSession$MdocApp$$anonfun$1$Cat$1.func(multiple-statements.md:9)
+                          |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:10)
+                          |// 	at repl.MdocSession$MdocApp$$anonfun$1.apply(multiple-statements.md:8)
                           |```""".stripMargin
     )
   )

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -334,7 +334,7 @@ class DefaultSuite extends BaseMarkdownSuite {
        |throw new StackOverflowError()
        |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |java.lang.StackOverflowError
-       |	at repl.MdocSession$App.<init>(fatal-exception.md:8)
+       |	at repl.MdocSession$MdocApp.<init>(fatal-exception.md:8)
        |	at repl.MdocSession$.app(fatal-exception.md:3)
        |""".stripMargin
   )

--- a/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/ErrorSuite.scala
@@ -134,8 +134,8 @@ class ErrorSuite extends BaseMarkdownSuite {
     """.stripMargin,
     """|error: already-defined-scala3.md:4:5:
        |Double definition:
-       |val x: Int in class App at line 7 and
-       |val x: Int in class App at line 11
+       |val x: Int in class MdocApp at line 7 and
+       |val x: Int in class MdocApp at line 11
        |
        |val x = 2
        |    ^

--- a/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/NestSuite.scala
@@ -69,7 +69,7 @@ class NestSuite extends BaseMarkdownSuite {
        |val hakon = User("Hakon", 42)
        |// hakon: User = User("Hakon", 42)
        |susan
-       |// res0: App.this.type.User = User("Susan")
+       |// res0: MdocApp.this.type.User = User("Susan")
        |```
        |""".stripMargin,
     compat = Map(
@@ -84,7 +84,7 @@ class NestSuite extends BaseMarkdownSuite {
            |val hakon = User("Hakon", 42)
            |// hakon: User = User(name = "Hakon", age = 42)
            |susan
-           |// res0: App.this.type.User = User(name = "Susan")
+           |// res0: MdocApp.this.type.User = User(name = "Susan")
            |```
            |""".stripMargin,
       Compat.Scala3 ->
@@ -355,7 +355,7 @@ class NestSuite extends BaseMarkdownSuite {
       |```
     """.stripMargin,
     """|error: implicit-nok.md:9:1: ambiguous implicit values:
-       | both value x in class App of type => Int
+       | both value x in class MdocApp of type => Int
        | and value y of type Int
        | match expected type Int
        |implicitly[Int]
@@ -409,8 +409,8 @@ class NestSuite extends BaseMarkdownSuite {
        |boom(x > 4)
        |^^^^^^^^^^^
        |java.lang.IllegalArgumentException
-       |	at repl.MdocSession$App.boom$1(stacktrace.md:32)
-       |	at repl.MdocSession$App.<init>(stacktrace.md:35)
+       |	at repl.MdocSession$MdocApp.boom$1(stacktrace.md:32)
+       |	at repl.MdocSession$MdocApp.<init>(stacktrace.md:35)
        |	at repl.MdocSession$.app(stacktrace.md:3)
        |""".stripMargin,
     compat = Map(
@@ -419,8 +419,8 @@ class NestSuite extends BaseMarkdownSuite {
            |boom(x > 4)
            |^^^^^^^^^^^
            |java.lang.IllegalArgumentException
-           |	at repl.MdocSession$App.boom$1(stacktrace.md:32)
-           |	at repl.MdocSession$App.<init>(stacktrace.md:36)
+           |	at repl.MdocSession$MdocApp.boom$1(stacktrace.md:32)
+           |	at repl.MdocSession$MdocApp.<init>(stacktrace.md:36)
            |	at repl.MdocSession$.app(stacktrace.md:3)
            |""".stripMargin
     )

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -289,8 +289,8 @@ class WorksheetSuite extends BaseSuite {
       |crash(filename)
       |""".stripMargin,
     """|crash:4:1: error: java.lang.RuntimeException: boom
-       |	at repl.MdocSession$App.crash(crash.scala:8)
-       |	at repl.MdocSession$App.<init>(crash.scala:14)
+       |	at repl.MdocSession$MdocApp.crash(crash.scala:8)
+       |	at repl.MdocSession$MdocApp.<init>(crash.scala:14)
        |	at repl.MdocSession$.app(crash.scala:3)
        |
        |crash(filename)
@@ -299,8 +299,8 @@ class WorksheetSuite extends BaseSuite {
     compat = Map(
       Compat.Scala3 ->
         """|crash:4:1: error: java.lang.RuntimeException: boom
-           |	at repl.MdocSession$App.crash(crash.scala:7)
-           |	at repl.MdocSession$App.<init>(crash.scala:15)
+           |	at repl.MdocSession$MdocApp.crash(crash.scala:7)
+           |	at repl.MdocSession$MdocApp.<init>(crash.scala:15)
            |	at repl.MdocSession$.app(crash.scala:3)
            |
            |crash(filename)
@@ -404,7 +404,7 @@ class WorksheetSuite extends BaseSuite {
         |val xx = fn
         |""".stripMargin,
     """|dotty-ambiguous-implicit:8:12: error:
-       |ambiguous implicit arguments: both object c1 in class App and object c2 in class App match type App.this.C of parameter c of method fn in class App
+       |ambiguous implicit arguments: both object c1 in class MdocApp and object c2 in class MdocApp match type MdocApp.this.C of parameter c of method fn in class MdocApp
        |val xx = fn
        |           ^
        |""".stripMargin


### PR DESCRIPTION
`App` is a common name which conflicts with some codes and there is no meaningful workaround I think. so I renamed it to a more descriptive name that is also extremely hard to get ambiguous reference error from.
it might resolve https://github.com/scalameta/mdoc/issues/204 too.

```
info] Reference to App is ambiguous,
[info] it is both defined in object MdocSession
[info] and inherited subsequently in object Foo
```