### PR TITLE
bugfix: [Scala 3] Reset context before each fail section

### DIFF
--- a/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/FailSuite.scala
@@ -377,4 +377,53 @@ class FailSuite extends BaseMarkdownSuite {
     """.stripMargin
     )
   )
+  check(
+    "two-errors",
+    """
+      |```scala mdoc:fail
+      |val nope = "foo" * "goo"
+      |```
+      |
+      |```scala mdoc:fail
+      |val bad = "moo" * "loo"
+      |```
+    """.stripMargin,
+    """|```scala
+       |val nope = "foo" * "goo"
+       |// error: type mismatch;
+       |//  found   : String("goo")
+       |//  required: Int
+       |```
+       |
+       |```scala
+       |val bad = "moo" * "loo"
+       |// error: type mismatch;
+       |//  found   : String("loo")
+       |//  required: Int
+       |// val bad = "moo" * "loo"
+       |//                   ^^^^^
+       |```
+       |""".stripMargin,
+    compat = Map(
+      Compat.Scala3 ->
+        """|```scala
+           |val nope = "foo" * "goo"
+           |// error:
+           |// Found:    ("goo" : String)
+           |// Required: Int
+           |// val nope = "foo" * "goo"
+           |//                    ^^^^^
+           |```
+           |
+           |```scala
+           |val bad = "moo" * "loo"
+           |// error:
+           |// Found:    ("loo" : String)
+           |// Required: Int
+           |// val bad = "moo" * "loo"
+           |//                   ^^^^^
+           |```
+           |""".stripMargin
+    )
+  )
 }


### PR DESCRIPTION
Previously, we were using the same reporter for each fail section, which was causing no more errors to be reported on the next section.

Now, we reset the context before compiling, which is creating a new reporter each time and that was already done for `compile`

I also tidied it a bit to only use the currently available context which will be fresh on `reset` always.

Fixes https://github.com/scalameta/mdoc/issues/663