### PR TITLE
bugfix: Allow mdoc work with the future versions of the compiler

### DIFF
--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -93,6 +93,11 @@ object MdocPlugin extends AutoPlugin {
           runMain.in(Compile).toTask(s" mdoc.Main $args")
         }
       }.evaluated,
+      dependencyOverrides ++= List(
+        "org.scala-lang" %% "scala3-library" % scalaVersion.value,
+        "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
+        "org.scala-lang" %% "tasty-core" % scalaVersion.value
+      ),
       libraryDependencies ++= {
         val isJS = mdocJS.value.isDefined
         if (mdocAutoDependency.value) {

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / scalaVersion := "2.12.16"
-ThisBuild / crossScalaVersions := List("2.12.16", "2.13.8", "3.1.3")
+ThisBuild / crossScalaVersions := List("2.12.16", "2.13.8", "3.1.3", "3.2.0-RC2")
 
 enablePlugins(MdocPlugin)
 mdocJS := Some(jsapp)

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
@@ -4,5 +4,7 @@
 > check
 > ++3.1.3 mdoc
 > check
+> ++3.2.0-RC2 mdoc
+> check
 > set mdocIn := (ThisBuild / baseDirectory).value
 -> mdoc


### PR DESCRIPTION
Previously, we would always include the Scala 3.1.3 compiler dependency, which wouldn't understand later Scala version. Now, we force the current version of the compiler, which should work until the limited API that we use stays the same. We already work on this asumptions for Scala 2.