### PR TITLE
Implement --check-link-hygiene

### DIFF
--- a/cli/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/cli/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -61,6 +61,10 @@ case class Settings(
     check: Boolean = false,
     @Description("Disable link hygiene analysis so that no warnings are reported for dead links.")
     noLinkHygiene: Boolean = false,
+    @Description(
+      "Link hygiene analysis reports dead links as errors. Useful for asserting in CI that the site contains no dead links. This setting has no effect in watch mode. It is also mutually exclusive with --no-link-hygiene, if both are set, link hygiene is disabled."
+    )
+    checkLinkHygiene: Boolean = false,
     @Description("Include additional diagnostics for debugging potential problems.")
     verbose: Boolean = false,
     @Description(

--- a/mdoc-docs/src/main/scala/mdoc/docs/MdocModifier.scala
+++ b/mdoc-docs/src/main/scala/mdoc/docs/MdocModifier.scala
@@ -35,7 +35,8 @@ class MdocModifier(context: Context) extends StringModifier {
       myContext.settings
     )
     val links = DocumentLinks.fromMarkdown(GitHubIdGenerator, file.relpath, cleanInput)
-    LinkHygiene.lint(List(links), myReporter, verbose = false)
+    val results = LinkHygiene.lint(List(links), verbose = false)
+    LinkHygiene.report(asError = false, results, reporter)
     val stdout = fansi.Str(myStdout.toString()).plainText
     if (myReporter.hasErrors || myReporter.hasWarnings) {
       if (info != "crash") {

--- a/mdoc/src/main/scala/mdoc/MainSettings.scala
+++ b/mdoc/src/main/scala/mdoc/MainSettings.scala
@@ -80,6 +80,9 @@ final class MainSettings private (
   def withNoLinkHygiene(noLinkHygiene: Boolean): MainSettings = {
     copy(settings.copy(noLinkHygiene = noLinkHygiene))
   }
+  def withCheckLinkHygiene(checkLinkHygiene: Boolean): MainSettings = {
+    copy(settings.copy(checkLinkHygiene = checkLinkHygiene))
+  }
   def withReportRelativePaths(reportRelativePaths: Boolean): MainSettings = {
     copy(settings.copy(reportRelativePaths = reportRelativePaths))
   }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/DocumentLinks.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/DocumentLinks.scala
@@ -47,7 +47,7 @@ object DocumentLinks {
   private val HtmlName = "name=\"([^\"]+)\"".r
   private val HtmlId = "id=\"([^\"]+)\"".r
 
-  def fromGeneratedSite(settings: Settings, reporter: Reporter): List[DocumentLinks] = {
+  def fromGeneratedSite(settings: Settings): List[DocumentLinks] = {
     val links = List.newBuilder[DocumentLinks]
     IO.foreachOutput(settings) { (abspath, relpath) =>
       val isMarkdown = PathIO.extension(relpath.toNIO) == "md"

--- a/tests/unit/src/test/scala/tests/markdown/CheckLinkHygieneSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/CheckLinkHygieneSuite.scala
@@ -1,0 +1,24 @@
+package tests.markdown
+
+import tests.cli.BaseCliSuite
+
+class CheckLinkHygieneSuite extends BaseCliSuite {
+  val original =
+    """/readme.md
+      |# Header
+      |
+      |[Head](#head)
+    """.stripMargin
+
+  checkCli(
+    "fails",
+    original,
+    original,
+    extraArgs = Array(
+      "--check-link-hygiene"
+    ),
+    onStdout = { out => assert(out.contains("error")) },
+    expectedExitCode = 1
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
@@ -7,64 +7,65 @@ import mdoc.internal.cli.Settings
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.DocumentLinks
 import mdoc.internal.markdown.LinkHygiene
+import mdoc.internal.markdown.DeadLinkInfo
+import scala.meta.inputs.Position
+import scala.meta.inputs.Input
 
 class LinkHygieneSuite extends FunSuite {
-  private val myOut = new ByteArrayOutputStream()
-  private val reporter = new ConsoleReporter(new PrintStream(myOut))
   def check(
       name: String,
       original: String,
-      expected: String,
+      expected: List[DeadLinkInfo],
       verbose: Boolean = false
   )(implicit loc: munit.Location): Unit = {
     test(name) {
-      myOut.reset()
-      reporter.reset()
       val root = tests.cli.StringFS.fromString(original)
       val settings = Settings
         .default(root)
         .copy(reportRelativePaths = true, in = List(root), out = List(root))
-      val links = DocumentLinks.fromGeneratedSite(settings, reporter)
-      LinkHygiene.lint(links, reporter, verbose)
-      val obtained = fansi.Str(myOut.toString()).plainText
-      assertNoDiff(obtained, expected)
+      val links = DocumentLinks.fromGeneratedSite(settings)
+      val obtained = LinkHygiene.lint(links, verbose)
+      assertEquals(obtained, expected)
     }
   }
-
+  val testContent1 =
+    s"""|# Section
+        |
+        |Error [link](#does-not-exist) failed.
+        |Typo [section](#sectionn) failed.
+        |
+        |## Sub-section
+        |
+        |<a id="id"></a>
+        |<a name="name"></a>
+        |
+        |Internal:
+        |* [section](#section)
+        |* [sub](#sub-section)
+        |* [id](#id)å
+        |* [name](#name)
+        |
+        |Explicit file path:
+        |* [section](a.md#section)
+        |* [sub](a.md#sub-section)
+        |* [id](a.md#id)
+        |* [name](a.md#name)
+        |""".stripMargin
   check(
     "single-file",
-    """
-      |/a.md
-      |# Section
-      |
-      |Error [link](#does-not-exist) failed.
-      |Typo [section](#sectionn) failed.
-      |
-      |## Sub-section
-      |
-      |<a id="id"></a>
-      |<a name="name"></a>
-      |
-      |Internal:
-      |* [section](#section)
-      |* [sub](#sub-section)
-      |* [id](#id)
-      |* [name](#name)
-      |
-      |Explicit file path:
-      |* [section](a.md#section)
-      |* [sub](a.md#sub-section)
-      |* [id](a.md#id)
-      |* [name](a.md#name)
-      |
-    """.stripMargin,
-    """|warning: a.md:3:7: Unknown link 'a.md#does-not-exist'.
-       |Error [link](#does-not-exist) failed.
-       |      ^^^^^^^^^^^^^^^^^^^^^^^
-       |warning: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
-       |Typo [section](#sectionn) failed.
-       |     ^^^^^^^^^^^^^^^^^^^^
-    """.stripMargin
+    s"""
+       |/a.md
+       |$testContent1""".stripMargin,
+    List(
+      DeadLinkInfo(
+        Position.Range(Input.VirtualFile("a.md", testContent1), 17, 40),
+        "Unknown link 'a.md#does-not-exist'."
+      ),
+      DeadLinkInfo(
+        Position.Range(Input.VirtualFile("a.md", testContent1), 54, 74),
+        "Unknown link 'a.md#sectionn', did you mean 'a.md#section'?"
+      )
+    )
   )
 
   check(
@@ -78,7 +79,7 @@ class LinkHygieneSuite extends FunSuite {
       |[a](a.md#a)
       |
     """.stripMargin,
-    ""
+    List.empty
   )
 
   check(
@@ -92,7 +93,7 @@ class LinkHygieneSuite extends FunSuite {
       |/b/b.md
       |# B
     """.stripMargin,
-    ""
+    List.empty
   )
 
   check(
@@ -101,40 +102,81 @@ class LinkHygieneSuite extends FunSuite {
       |/a.md
       |![i](/static/logo.png)
     """.stripMargin,
-    ""
+    List.empty
   )
 
+  val testContent2 = "[absolute](/absolute.md)"
   check(
     "absolute",
-    """
-      |/a.md
-      |[absolute](/absolute.md)
-    """.stripMargin,
-    """|warning: a.md:1:1: Unknown link '/absolute.md', did you mean 'a.md'? To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md.
-       |[absolute](/absolute.md)
-       |^^^^^^^^^^^^^^^^^^^^^^^^
-       |""".stripMargin
+    s"""
+       |/a.md
+       |$testContent2""".stripMargin,
+    List(
+      DeadLinkInfo(
+        Position.Range(Input.VirtualFile("a.md", testContent2), 0, 24),
+        "Unknown link '/absolute.md', did you mean 'a.md'? To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md."
+      )
+    )
   )
 
+  val testContent3 =
+    """|# Header 1
+       |[2](b.md#header)
+       |""".stripMargin
   check(
     "verbose",
-    """
-      |/a.md
-      |# Header 1
-      |[2](b.md#header)
-      |/b.md
-      |# Header 2
+    s"""
+       |/a.md
+       |$testContent3
+       |/b.md
+       |# Header 2
     """.stripMargin,
-    """|warning: a.md:2:1: Unknown link 'b.md#header', did you mean 'b.md#header-2'?
-       |isValidHeading:
-       |  a.md
-       |  a.md#header-1
-       |  b.md
-       |  b.md#header-2
-       |[2](b.md#header)
-       |^^^^^^^^^^^^^^^^
-       |""".stripMargin,
+    List(
+      DeadLinkInfo(
+        Position.Range(Input.VirtualFile("a.md", testContent3), 11, 27),
+        """|Unknown link 'b.md#header', did you mean 'b.md#header-2'?
+           |isValidHeading:
+           |  a.md
+           |  a.md#header-1
+           |  b.md
+           |  b.md#header-2""".stripMargin
+      )
+    ),
     verbose = true
   )
+
+  test("console rendering") {
+    val myOut = new ByteArrayOutputStream()
+    val reporter = new ConsoleReporter(new PrintStream(myOut))
+    val original =
+      s"""|/a.md
+          |$testContent1""".stripMargin
+    myOut.reset()
+    reporter.reset()
+    val root = tests.cli.StringFS.fromString(original)
+    val settings = Settings
+      .default(root)
+      .copy(reportRelativePaths = true, in = List(root), out = List(root))
+    val links = DocumentLinks.fromGeneratedSite(settings)
+    val result = LinkHygiene.lint(links, false)
+    val resultVerbose = LinkHygiene.lint(links, true)
+    LinkHygiene.report(asError = true, result, reporter)
+    LinkHygiene.report(asError = false, result, reporter)
+    val obtained = fansi.Str(myOut.toString()).plainText
+    val expected =
+      """|error: a.md:3:7: Unknown link 'a.md#does-not-exist'.
+         |Error [link](#does-not-exist) failed.
+         |      ^^^^^^^^^^^^^^^^^^^^^^^
+         |error: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
+         |Typo [section](#sectionn) failed.
+         |     ^^^^^^^^^^^^^^^^^^^^
+         |warning: a.md:3:7: Unknown link 'a.md#does-not-exist'.
+         |Error [link](#does-not-exist) failed.
+         |      ^^^^^^^^^^^^^^^^^^^^^^^
+         |warning: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
+         |Typo [section](#sectionn) failed.
+         |     ^^^^^^^^^^^^^^^^^^^^""".stripMargin
+    assertNoDiff(obtained, expected)
+  }
 
 }

--- a/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/LinkHygieneSuite.scala
@@ -7,65 +7,64 @@ import mdoc.internal.cli.Settings
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.DocumentLinks
 import mdoc.internal.markdown.LinkHygiene
-import mdoc.internal.markdown.DeadLinkInfo
-import scala.meta.inputs.Position
-import scala.meta.inputs.Input
 
 class LinkHygieneSuite extends FunSuite {
+  private val myOut = new ByteArrayOutputStream()
+  private val reporter = new ConsoleReporter(new PrintStream(myOut))
   def check(
       name: String,
       original: String,
-      expected: List[DeadLinkInfo],
+      expected: String,
       verbose: Boolean = false
   )(implicit loc: munit.Location): Unit = {
     test(name) {
+      myOut.reset()
+      reporter.reset()
       val root = tests.cli.StringFS.fromString(original)
       val settings = Settings
         .default(root)
         .copy(reportRelativePaths = true, in = List(root), out = List(root))
-      val links = DocumentLinks.fromGeneratedSite(settings)
-      val obtained = LinkHygiene.lint(links, verbose)
-      assertEquals(obtained, expected)
+      val links = DocumentLinks.fromGeneratedSite(settings, reporter)
+      LinkHygiene.lint(links, reporter, verbose)
+      val obtained = fansi.Str(myOut.toString()).plainText
+      assertNoDiff(obtained, expected)
     }
   }
-  val testContent1 =
-    s"""|# Section
-        |
-        |Error [link](#does-not-exist) failed.
-        |Typo [section](#sectionn) failed.
-        |
-        |## Sub-section
-        |
-        |<a id="id"></a>
-        |<a name="name"></a>
-        |
-        |Internal:
-        |* [section](#section)
-        |* [sub](#sub-section)
-        |* [id](#id)å
-        |* [name](#name)
-        |
-        |Explicit file path:
-        |* [section](a.md#section)
-        |* [sub](a.md#sub-section)
-        |* [id](a.md#id)
-        |* [name](a.md#name)
-        |""".stripMargin
+
   check(
     "single-file",
-    s"""
-       |/a.md
-       |$testContent1""".stripMargin,
-    List(
-      DeadLinkInfo(
-        Position.Range(Input.VirtualFile("a.md", testContent1), 17, 40),
-        "Unknown link 'a.md#does-not-exist'."
-      ),
-      DeadLinkInfo(
-        Position.Range(Input.VirtualFile("a.md", testContent1), 54, 74),
-        "Unknown link 'a.md#sectionn', did you mean 'a.md#section'?"
-      )
-    )
+    """
+      |/a.md
+      |# Section
+      |
+      |Error [link](#does-not-exist) failed.
+      |Typo [section](#sectionn) failed.
+      |
+      |## Sub-section
+      |
+      |<a id="id"></a>
+      |<a name="name"></a>
+      |
+      |Internal:
+      |* [section](#section)
+      |* [sub](#sub-section)
+      |* [id](#id)
+      |* [name](#name)
+      |
+      |Explicit file path:
+      |* [section](a.md#section)
+      |* [sub](a.md#sub-section)
+      |* [id](a.md#id)
+      |* [name](a.md#name)
+      |
+    """.stripMargin,
+    """|warning: a.md:3:7: Unknown link 'a.md#does-not-exist'.
+       |Error [link](#does-not-exist) failed.
+       |      ^^^^^^^^^^^^^^^^^^^^^^^
+       |warning: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
+       |Typo [section](#sectionn) failed.
+       |     ^^^^^^^^^^^^^^^^^^^^
+    """.stripMargin
   )
 
   check(
@@ -79,7 +78,7 @@ class LinkHygieneSuite extends FunSuite {
       |[a](a.md#a)
       |
     """.stripMargin,
-    List.empty
+    ""
   )
 
   check(
@@ -93,7 +92,7 @@ class LinkHygieneSuite extends FunSuite {
       |/b/b.md
       |# B
     """.stripMargin,
-    List.empty
+    ""
   )
 
   check(
@@ -102,81 +101,40 @@ class LinkHygieneSuite extends FunSuite {
       |/a.md
       |![i](/static/logo.png)
     """.stripMargin,
-    List.empty
+    ""
   )
 
-  val testContent2 = "[absolute](/absolute.md)"
   check(
     "absolute",
-    s"""
-       |/a.md
-       |$testContent2""".stripMargin,
-    List(
-      DeadLinkInfo(
-        Position.Range(Input.VirtualFile("a.md", testContent2), 0, 24),
-        "Unknown link '/absolute.md', did you mean 'a.md'? To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md."
-      )
-    )
+    """
+      |/a.md
+      |[absolute](/absolute.md)
+    """.stripMargin,
+    """|warning: a.md:1:1: Unknown link '/absolute.md', did you mean 'a.md'? To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/absolute.md.
+       |[absolute](/absolute.md)
+       |^^^^^^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
   )
 
-  val testContent3 =
-    """|# Header 1
-       |[2](b.md#header)
-       |""".stripMargin
   check(
     "verbose",
-    s"""
-       |/a.md
-       |$testContent3
-       |/b.md
-       |# Header 2
+    """
+      |/a.md
+      |# Header 1
+      |[2](b.md#header)
+      |/b.md
+      |# Header 2
     """.stripMargin,
-    List(
-      DeadLinkInfo(
-        Position.Range(Input.VirtualFile("a.md", testContent3), 11, 27),
-        """|Unknown link 'b.md#header', did you mean 'b.md#header-2'?
-           |isValidHeading:
-           |  a.md
-           |  a.md#header-1
-           |  b.md
-           |  b.md#header-2""".stripMargin
-      )
-    ),
+    """|warning: a.md:2:1: Unknown link 'b.md#header', did you mean 'b.md#header-2'?
+       |isValidHeading:
+       |  a.md
+       |  a.md#header-1
+       |  b.md
+       |  b.md#header-2
+       |[2](b.md#header)
+       |^^^^^^^^^^^^^^^^
+       |""".stripMargin,
     verbose = true
   )
-
-  test("console rendering") {
-    val myOut = new ByteArrayOutputStream()
-    val reporter = new ConsoleReporter(new PrintStream(myOut))
-    val original =
-      s"""|/a.md
-          |$testContent1""".stripMargin
-    myOut.reset()
-    reporter.reset()
-    val root = tests.cli.StringFS.fromString(original)
-    val settings = Settings
-      .default(root)
-      .copy(reportRelativePaths = true, in = List(root), out = List(root))
-    val links = DocumentLinks.fromGeneratedSite(settings)
-    val result = LinkHygiene.lint(links, false)
-    val resultVerbose = LinkHygiene.lint(links, true)
-    LinkHygiene.report(asError = true, result, reporter)
-    LinkHygiene.report(asError = false, result, reporter)
-    val obtained = fansi.Str(myOut.toString()).plainText
-    val expected =
-      """|error: a.md:3:7: Unknown link 'a.md#does-not-exist'.
-         |Error [link](#does-not-exist) failed.
-         |      ^^^^^^^^^^^^^^^^^^^^^^^
-         |error: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
-         |Typo [section](#sectionn) failed.
-         |     ^^^^^^^^^^^^^^^^^^^^
-         |warning: a.md:3:7: Unknown link 'a.md#does-not-exist'.
-         |Error [link](#does-not-exist) failed.
-         |      ^^^^^^^^^^^^^^^^^^^^^^^
-         |warning: a.md:4:6: Unknown link 'a.md#sectionn', did you mean 'a.md#section'?
-         |Typo [section](#sectionn) failed.
-         |     ^^^^^^^^^^^^^^^^^^^^""".stripMargin
-    assertNoDiff(obtained, expected)
-  }
 
 }

--- a/tests/unit/src/test/scala/tests/markdown/NoLinkWarningSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/NoLinkWarningSuite.scala
@@ -20,4 +20,21 @@ class NoLinkWarningSuite extends BaseCliSuite {
     onStdout = { out => assert(!out.contains("warning")) }
   )
 
+  checkCli(
+    "nowarn override --check-link-hygiene",
+    original,
+    original,
+    extraArgs = Array(
+      "--no-link-hygiene",
+      "--check-link-hygiene"
+    ),
+    onStdout = { out =>
+      assert(
+        out.contains(
+          "warning: --no-link-hygiene and --check-link-hygiene are mutually exclusive. Link hygiene is disabled."
+        )
+      )
+    }
+  )
+
 }


### PR DESCRIPTION
Adds a setting to report link hygiene analysis as error and
turn a potentially successful execution into an error.

Address https://github.com/scalameta/mdoc/issues/679