### PR TITLE
Check-link-hygiene bug fix and sbt integration tweak

### DIFF
--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -90,7 +90,7 @@ object MdocPlugin extends AutoPlugin {
           parsed
         ).flatten.mkString(" ")
         Def.taskDyn {
-          runMain.in(Compile).toTask(s" mdoc.Main $args")
+          runMain.in(Compile).toTask(s" mdoc.SbtMain $args")
         }
       }.evaluated,
       dependencyOverrides ++= List(

--- a/mdoc/src/main/scala/mdoc/Main.scala
+++ b/mdoc/src/main/scala/mdoc/Main.scala
@@ -10,13 +10,21 @@ import mdoc.internal.cli.Settings
 import mdoc.internal.io.ConsoleReporter
 import mdoc.internal.markdown.Markdown
 
-object Main {
-
+object Main extends MainProcess {
   def main(args: Array[String]): Unit = {
     val code = process(args, System.out, PathIO.workingDirectory.toNIO)
     if (code != 0) sys.exit(code)
   }
+}
 
+object SbtMain extends MainProcess {
+  def main(args: Array[String]): Unit = {
+    val code = process(args, System.out, PathIO.workingDirectory.toNIO)
+    if (code != 0) sys.error("mdoc failed")
+  }
+}
+
+trait MainProcess {
   def process(args: Array[String], out: PrintStream, cwd: Path): Int = {
     process(args, new ConsoleReporter(out), cwd)
   }
@@ -28,5 +36,4 @@ object Main {
   def process(settings: MainSettings): Int = {
     MainOps.process(Configured.ok(settings.settings), settings.reporter)
   }
-
 }

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -70,7 +70,8 @@ final class MainOps(
         val docs = DocumentLinks.fromGeneratedSite(settings)
         val results = LinkHygiene.lint(docs, settings.verbose)
         LinkHygiene.report(settings.checkLinkHygiene, results, reporter)
-        if (settings.checkLinkHygiene) {
+
+        if (settings.checkLinkHygiene && results.nonEmpty) {
           acc.merge(Exit.error)
         } else {
           acc.merge(Exit.success)


### PR DESCRIPTION
That's my bad, the check to decide whether to return exit code 1 or 0 is incorrect after my changes for the check-link-hygiene. That is: I returned `Error` when when there were no warnings... Found it while integrating: https://github.com/disneystreaming/smithy4s/pull/472

Also, we noticed that when using --check or --check-link-hygiene from sbt, the SBT jvm will exit and it's annoying. To fix that, I introduce a `SbtMain` to be used when calling from a jvm.

Happy to rename `SbtMain` because I guess there are other tools (like `mill`) that would be calling that.

wdyt?