### PR TITLE
bugfix: Specify main class to run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,15 +211,7 @@ lazy val mdoc = project
     sharedSettings,
     Compile / unmanagedSourceDirectories ++= multiScalaDirectories("mdoc").value,
     moduleName := "mdoc",
-    assembly / mainClass := Some("mdoc.Main"),
-    assembly / assemblyJarName := "mdoc.jar",
-    assembly / test := {},
-    assembly / assemblyMergeStrategy ~= { old =>
-      {
-        case PathList("META-INF", "CHANGES") => MergeStrategy.discard
-        case x => old(x)
-      }
-    },
+    Compile / mainClass := Some("mdoc.Main"),
     run / fork := true,
     buildInfoPackage := "mdoc.internal",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")


### PR DESCRIPTION
Previously, mainClass would only be specified for assembly which is not used in publishing. Now we specify mainClass for the Compile scope, which makes it end up in the jar correctly.

I also removed sbt-assembly since we don't seem to be using it at all currently.

Fixes https://github.com/scalameta/mdoc/issues/705