### PR TITLE
bugfix: Revert undertow bump since it's now published with Java 11

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,8 @@ pullRequests.frequency = "@monthly"
 updates.ignore = [
   { groupId = "org.scala-js" }
   { groupId = "ch.epfl.scala", artifactId = "sbt-scalajs-bundler" }
+  // https://github.com/undertow-io/undertow/pull/1310/commits/4521635d2f1d2eece5d6681d1e00be32bac95d0c
+  { groupId = "io.undertow" }
 ]
 updates.pin = [
   { groupId = "org.scala-lang", artifactId="scala3-compiler", version = "3.1." },

--- a/build.sbt
+++ b/build.sbt
@@ -238,7 +238,7 @@ lazy val mdoc = project
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "io.methvin" % "directory-watcher" % "0.16.1",
       // live reload
-      "io.undertow" % "undertow-core" % "2.3.0.Final",
+      "io.undertow" % "undertow-core" % "2.2.20.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.8.Final",
       "org.slf4j" % "slf4j-api" % "2.0.3",
       "com.geirsson" %% "metaconfig-typesafe-config" % V.metaconfig,


### PR DESCRIPTION
More global question here is whether we should stop releasing thing with JDK 8, since I see more and more libraries doing it