### PR TITLE
Run in background

### DIFF
--- a/cli/src/main/scala/mdoc/internal/cli/Settings.scala
+++ b/cli/src/main/scala/mdoc/internal/cli/Settings.scala
@@ -53,6 +53,9 @@ case class Settings(
     @Description("Start a file watcher and incrementally re-generate the site on file save.")
     @ExtraName("w")
     watch: Boolean = false,
+    @Description("Sets the file watcher to run in the background and not ask for user input in order to stop.")
+    @ExtraName("b")
+    background: Boolean = false,
     @Description(
       "Instead of generating a new site, report an error if generating the site would produce a diff " +
         "against an existing site. Useful for asserting in CI that a site is up-to-date."

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,12 +105,11 @@ performance.
 > docs/mdoc --watch
 ```
 
-If running mdoc as a background job in sbt then you should enable watch mode
-with the `--background` argument so that it is non-interactive and you can
-still issue commands to sbt.
+You can run mdoc in the background so that you can issue other commands to sbt.
 
 ```scala
-> docs/bgRunMain mdoc.SbtMain --watch --background
+> docs/mdocBgStart
+> docs/mdocBgStop
 ```
 
 See [`--help`](#help) to learn more how to use the command-line interface.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,6 +105,14 @@ performance.
 > docs/mdoc --watch
 ```
 
+If running mdoc as a background job in sbt then you should enable watch mode
+with the `--background` argument so that it is non-interactive and you can
+still issue commands to sbt.
+
+```scala
+> docs/bgRunMain mdoc.SbtMain --watch --background
+```
+
 See [`--help`](#help) to learn more how to use the command-line interface.
 
 ```scala

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/build.sbt
@@ -1,0 +1,14 @@
+ThisBuild / scalaVersion := "2.12.17"
+
+enablePlugins(MdocPlugin)
+
+TaskKey[Unit]("check") := {
+  SbtTest.test(
+    TestCommand("mdocBgStart", "Waiting for file changes (press enter to interrupt)"),
+    TestCommand("show version", "[info] 0.1.0-SNAPSHOT"),
+    TestCommand("mdocBgStart", "mdoc is already running in the background"),
+    TestCommand("mdocBgStop", "stopping mdoc"),
+    TestCommand("mdocBgStop", "mdoc is not running in the background"),
+    TestCommand("exit")
+  )
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/docs/readme.md
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/docs/readme.md
@@ -1,0 +1,3 @@
+```scala mdoc
+println(example.Example.greeting)
+```

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/SbtTest.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/SbtTest.scala
@@ -1,0 +1,77 @@
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.LinkedBlockingQueue
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.sys.process._
+
+object SbtTest {
+
+  def test(commands: TestCommand*) = {
+    val commandsToSend = new LinkedBlockingQueue[String]()
+    def sendInput(output: java.io.OutputStream): Unit = {
+      val newLine = "\n".getBytes(StandardCharsets.UTF_8)
+      try {
+        while (true) {
+          val command = commandsToSend.take()
+          output.write(command.getBytes(StandardCharsets.UTF_8))
+          output.write(newLine)
+          output.flush()
+        }
+      } catch {
+        case _: InterruptedException => // Ignore
+      } finally {
+        output.close()
+      }
+    }
+
+    val commandQueue: mutable.Queue[TestCommand] = mutable.Queue(commands: _*)
+    var expectedOutput: Option[String] = Some("[info] started sbt server")
+    def processOut(out: String): Unit = {
+      if (expectedOutput.forall(out.endsWith)) {
+        if (commandQueue.nonEmpty) {
+          val command = commandQueue.dequeue()
+          Thread.sleep(command.delay.toMillis)
+          commandsToSend.put(command.command)
+          expectedOutput = command.expectedOutput
+        }
+      }
+      println(s"[SbtTest] $out")
+    }
+
+    val error = new StringBuilder()
+    def processError(err: String): Unit = {
+      println(s"[SbtTest error] $err")
+      error.append(err)
+    }
+
+    // TODO: Do we need the -Xmx setting and any other future options?
+    val command = Seq(
+      "sbt",
+      s"-Dplugin.version=${sys.props("plugin.version")}",
+      "--no-colors",
+      "--supershell=never"
+    )
+    val logger = ProcessLogger(processOut, processError)
+    val basicIO = BasicIO(withIn = false, logger)
+    val io = new ProcessIO(sendInput, basicIO.processOutput, basicIO.processError)
+    val p = command.run(io)
+
+    val deadline = 30.seconds.fromNow
+    Future {
+      while (p.isAlive()) {
+        if (deadline.isOverdue()) {
+          p.destroy()
+        }
+      }
+    }
+
+    val code = p.exitValue()
+
+    expectedOutput.foreach { expected =>
+      throw new AssertionError(s"Expected to find output: $expected")
+    }
+    assert(code == 0, s"Expected exit code 0 but got $code")
+  }
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/TestCommand.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/TestCommand.scala
@@ -1,0 +1,22 @@
+import scala.concurrent.duration._
+
+/**
+  * @param command the command to send
+  * @param expectedOutput expected output of the command
+  * @param delay time to wait before sending the command
+  */
+final case class TestCommand(command: String, expectedOutput: Option[String], delay: FiniteDuration)
+
+object TestCommand {
+  def apply(command: String, expectedOutput: String, delay: FiniteDuration): TestCommand =
+    TestCommand(command, Some(expectedOutput), delay)
+
+  def apply(command: String, expectedOutput: String): TestCommand =
+    TestCommand(command, Some(expectedOutput), Duration.Zero)
+
+  def apply(command: String, delay: FiniteDuration): TestCommand =
+    TestCommand(command, None, delay)
+
+  def apply(command: String): TestCommand =
+    TestCommand(command, None, Duration.Zero)
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/build.properties
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.8.2

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/src/main/scala/example/Example.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/src/main/scala/example/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+object Example {
+  def greeting = "Hello world!"
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/bg-tasks/test
@@ -1,0 +1,3 @@
+# Not sure why we need to do this. If we don't it fails with java.nio.file.NoSuchFileException.
+$ mkdir target/mdoc
+> check

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
@@ -1,9 +1,4 @@
-import java.nio.charset.StandardCharsets
-import java.util.concurrent.LinkedBlockingQueue
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.sys.process._
 import MdocPlugin._
 
 ThisBuild / scalaVersion := "2.12.17"
@@ -18,68 +13,9 @@ InputKey[Unit]("mdocBg") := Def.inputTaskDyn {
 }.evaluated
 
 TaskKey[Unit]("check") := {
-  val commands = new LinkedBlockingQueue[String]()
-  def sendInput(output: java.io.OutputStream): Unit = {
-    val newLine = "\n".getBytes(StandardCharsets.UTF_8)
-    try {
-      while (true) {
-        val command = commands.take()
-        output.write(command.getBytes(StandardCharsets.UTF_8))
-        output.write(newLine)
-        output.flush()
-      }
-    } catch {
-      case _: InterruptedException => // Ignore
-    } finally {
-      output.close()
-    }
-  }
-
-  val output = new StringBuilder()
-  def processOut(out: String): Unit = {
-    if (out.endsWith("[info] started sbt server")) {
-      commands.put("mdocBg --watch --background")
-    } else if (out.endsWith("Waiting for file changes (press enter to interrupt)")) {
-      // Wait for the input eating to start.
-      Thread.sleep(3000)
-      commands.put("show version")
-    } else if (out.endsWith("[info] 0.1.0-SNAPSHOT")) {
-      commands.put("")
-      commands.put("exit")
-    }
-    println(s"[TEST] $out")
-    output.append(out)
-    output.append('\n')
-  }
-
-  val error = new StringBuilder()
-  def processError(err: String): Unit = {
-    println(s"[TEST ERROR] $err")
-    error.append(err)
-    output.append('\n')
-  }
-
-  // TODO: Do we need the -Xmx setting and any other future options?
-  val command = Seq(
-    "sbt",
-    s"-Dplugin.version=${sys.props("plugin.version")}",
-    "--no-colors",
-    "--supershell=never"
+  SbtTest.test(
+    TestCommand("mdocBg --watch --background", "Waiting for file changes (press enter to interrupt)"),
+    TestCommand("show version", "[info] 0.1.0-SNAPSHOT", 3.seconds),
+    TestCommand("exit")
   )
-  val logger = ProcessLogger(processOut, processError)
-  val basicIO = BasicIO(withIn = false, logger)
-  val io = new ProcessIO(sendInput, basicIO.processOutput, basicIO.processError)
-  val p = command.run(io)
-  val deadline = Deadline.now + 30.seconds
-  Future {
-    while (p.isAlive()) {
-      if (deadline.isOverdue()) {
-        p.destroy()
-      }
-    }
-  }
-  p.exitValue()
-  val code = p.exitValue()
-
-  assert(code == 0, s"Expected exit code 0 but got $code")
 }

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
@@ -1,0 +1,85 @@
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.LinkedBlockingQueue
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.sys.process._
+import MdocPlugin._
+
+ThisBuild / scalaVersion := "2.12.17"
+
+enablePlugins(MdocPlugin)
+
+InputKey[Unit]("mdocBg") := Def.inputTaskDyn {
+  validateSettings.value
+  val parsed = sbt.complete.DefaultParsers.spaceDelimited("<arg>").parsed
+  val args = (mdocExtraArguments.value ++ parsed).mkString(" ")
+  (Compile / bgRunMain).toTask(s" mdoc.SbtMain $args")
+}.evaluated
+
+TaskKey[Unit]("check") := {
+  val commands = new LinkedBlockingQueue[String]()
+  def sendInput(output: java.io.OutputStream): Unit = {
+    val newLine = "\n".getBytes(StandardCharsets.UTF_8)
+    try {
+      while (true) {
+        val command = commands.take()
+        output.write(command.getBytes(StandardCharsets.UTF_8))
+        output.write(newLine)
+        output.flush()
+      }
+    } catch {
+      case _: InterruptedException => // Ignore
+    } finally {
+      output.close()
+    }
+  }
+
+  val output = new StringBuilder()
+  def processOut(out: String): Unit = {
+    if (out.endsWith("[info] started sbt server")) {
+      commands.put("mdocBg --watch")
+    } else if (out.endsWith("Waiting for file changes (press enter to interrupt)")) {
+      // Wait for the input eating to start.
+      Thread.sleep(3000)
+      commands.put("show version")
+    } else if (out.endsWith("[info] 0.1.0-SNAPSHOT")) {
+      commands.put("")
+      commands.put("exit")
+    }
+    println(s"[TEST] $out")
+    output.append(out)
+    output.append('\n')
+  }
+
+  val error = new StringBuilder()
+  def processError(err: String): Unit = {
+    println(s"[TEST ERROR] $err")
+    error.append(err)
+    output.append('\n')
+  }
+
+  // TODO: Do we need the -Xmx setting and any other future options?
+  val command = Seq(
+    "sbt",
+    s"-Dplugin.version=${sys.props("plugin.version")}",
+    "--no-colors",
+    "--supershell=never"
+  )
+  val logger = ProcessLogger(processOut, processError)
+  val basicIO = BasicIO(withIn = false, logger)
+  val io = new ProcessIO(sendInput, basicIO.processOutput, basicIO.processError)
+  val p = command.run(io)
+  val deadline = Deadline.now + 30.seconds
+  Future {
+    while (p.isAlive()) {
+      if (deadline.isOverdue()) {
+        p.destroy()
+      }
+    }
+  }
+  p.exitValue()
+  val code = p.exitValue()
+
+  assert(code == 0, s"Expected exit code 0 but got $code")
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/build.sbt
@@ -38,7 +38,7 @@ TaskKey[Unit]("check") := {
   val output = new StringBuilder()
   def processOut(out: String): Unit = {
     if (out.endsWith("[info] started sbt server")) {
-      commands.put("mdocBg --watch")
+      commands.put("mdocBg --watch --background")
     } else if (out.endsWith("Waiting for file changes (press enter to interrupt)")) {
       // Wait for the input eating to start.
       Thread.sleep(3000)

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/docs/readme.md
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/docs/readme.md
@@ -1,0 +1,3 @@
+```scala mdoc
+println(example.Example.greeting)
+```

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/SbtTest.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/SbtTest.scala
@@ -1,0 +1,77 @@
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.LinkedBlockingQueue
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.sys.process._
+
+object SbtTest {
+
+  def test(commands: TestCommand*) = {
+    val commandsToSend = new LinkedBlockingQueue[String]()
+    def sendInput(output: java.io.OutputStream): Unit = {
+      val newLine = "\n".getBytes(StandardCharsets.UTF_8)
+      try {
+        while (true) {
+          val command = commandsToSend.take()
+          output.write(command.getBytes(StandardCharsets.UTF_8))
+          output.write(newLine)
+          output.flush()
+        }
+      } catch {
+        case _: InterruptedException => // Ignore
+      } finally {
+        output.close()
+      }
+    }
+
+    val commandQueue: mutable.Queue[TestCommand] = mutable.Queue(commands: _*)
+    var expectedOutput: Option[String] = Some("[info] started sbt server")
+    def processOut(out: String): Unit = {
+      if (expectedOutput.forall(out.endsWith)) {
+        if (commandQueue.nonEmpty) {
+          val command = commandQueue.dequeue()
+          Thread.sleep(command.delay.toMillis)
+          commandsToSend.put(command.command)
+          expectedOutput = command.expectedOutput
+        }
+      }
+      println(s"[SbtTest] $out")
+    }
+
+    val error = new StringBuilder()
+    def processError(err: String): Unit = {
+      println(s"[SbtTest error] $err")
+      error.append(err)
+    }
+
+    // TODO: Do we need the -Xmx setting and any other future options?
+    val command = Seq(
+      "sbt",
+      s"-Dplugin.version=${sys.props("plugin.version")}",
+      "--no-colors",
+      "--supershell=never"
+    )
+    val logger = ProcessLogger(processOut, processError)
+    val basicIO = BasicIO(withIn = false, logger)
+    val io = new ProcessIO(sendInput, basicIO.processOutput, basicIO.processError)
+    val p = command.run(io)
+
+    val deadline = 30.seconds.fromNow
+    Future {
+      while (p.isAlive()) {
+        if (deadline.isOverdue()) {
+          p.destroy()
+        }
+      }
+    }
+
+    val code = p.exitValue()
+
+    expectedOutput.foreach { expected =>
+      throw new AssertionError(s"Expected to find output: $expected")
+    }
+    assert(code == 0, s"Expected exit code 0 but got $code")
+  }
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/TestCommand.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/TestCommand.scala
@@ -1,0 +1,22 @@
+import scala.concurrent.duration._
+
+/**
+  * @param command the command to send
+  * @param expectedOutput expected output of the command
+  * @param delay time to wait before sending the command
+  */
+final case class TestCommand(command: String, expectedOutput: Option[String], delay: FiniteDuration)
+
+object TestCommand {
+  def apply(command: String, expectedOutput: String, delay: FiniteDuration): TestCommand =
+    TestCommand(command, Some(expectedOutput), delay)
+
+  def apply(command: String, expectedOutput: String): TestCommand =
+    TestCommand(command, Some(expectedOutput), Duration.Zero)
+
+  def apply(command: String, delay: FiniteDuration): TestCommand =
+    TestCommand(command, None, delay)
+
+  def apply(command: String): TestCommand =
+    TestCommand(command, None, Duration.Zero)
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/build.properties
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.8.2

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/src/main/scala/example/Example.scala
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/src/main/scala/example/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+object Example {
+  def greeting = "Hello world!"
+}

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/run-in-background/test
@@ -1,0 +1,3 @@
+# Not sure why we need to do this. If we don't it fails with java.nio.file.NoSuchFileException.
+$ mkdir target/mdoc
+> check

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -1,6 +1,5 @@
 package mdoc.internal.cli
 
-import com.vladsch.flexmark.parser.Parser
 import io.methvin.watcher.DirectoryChangeEvent
 import io.methvin.watcher.hashing.FileHash
 import io.methvin.watcher.hashing.FileHasher
@@ -13,7 +12,6 @@ import mdoc.internal.livereload.UndertowLiveReload
 import mdoc.internal.markdown.DocumentLinks
 import mdoc.internal.markdown.LinkHygiene
 import mdoc.internal.markdown.Markdown
-import mdoc.internal.markdown.DeadLinkInfo
 import mdoc.internal.pos.DiffUtils
 import metaconfig.Configured
 
@@ -225,7 +223,8 @@ final class MainOps(
 
   def runFileWatcher(): Unit = {
     val executor = Executors.newFixedThreadPool(1)
-    val watcher = MdocFileListener.create(settings.in, executor, System.in)(handleWatchEvent)
+    val in = if (settings.background) None else Some(System.in)
+    val watcher = MdocFileListener.create(settings.in, executor, in)(handleWatchEvent)
     watcher.watchUntilInterrupted()
     this.livereload.foreach(_.stop())
   }

--- a/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
+++ b/mdoc/src/main/scala/mdoc/internal/cli/MainOps.scala
@@ -282,11 +282,16 @@ object MainOps {
               ctx.reporter.setDebugEnabled(true)
             }
             val runner = new MainOps(ctx)
-            val exit = runner.run()
-            if (exit.isSuccess) {
-              0
-            } else {
-              1 // error
+            try {
+              val exit = runner.run()
+              if (exit.isSuccess) {
+                0
+              } else {
+                1 // error
+              }
+            } catch {
+              case _: InterruptedException if ctx.settings.background =>
+                0 // It is expected that we are interrupted when running in the background.
             }
         }
     }

--- a/mdoc/src/main/scala/mdoc/internal/io/MdocFileListener.scala
+++ b/mdoc/src/main/scala/mdoc/internal/io/MdocFileListener.scala
@@ -7,21 +7,19 @@ import io.methvin.watcher.DirectoryWatcher
 import java.io.InputStream
 import java.nio.file.Files
 import java.util.Scanner
-import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
-import org.slf4j.Logger
 import org.slf4j.helpers.NOPLogger
 import scala.meta.io.AbsolutePath
 import mdoc.internal.pos.PositionSyntax._
 
 final class MdocFileListener(
     executor: ExecutorService,
-    in: InputStream,
-    runAction: DirectoryChangeEvent => Unit
+    in: Option[InputStream],
+    runAction: DirectoryChangeEvent => Unit,
 ) extends DirectoryChangeListener {
   private var myIsWatching: Boolean = true
   private var watcher: DirectoryWatcher = _
-  private def blockUntilEnterKey(): Unit = {
+  private def blockUntilEnterKey(in: InputStream): Unit = {
     try {
       new Scanner(in).nextLine()
       println("Shutting down...")
@@ -29,9 +27,16 @@ final class MdocFileListener(
       case _: NoSuchElementException =>
     }
   }
+  private def blockUntilInterrupted(): Unit = {
+    try {
+      this.wait()
+    } catch {
+      case _: InterruptedException =>
+    }
+  }
   def watchUntilInterrupted(): Unit = {
     watcher.watchAsync(executor)
-    blockUntilEnterKey()
+    in.fold(blockUntilInterrupted())(blockUntilEnterKey)
     executor.shutdown()
     myIsWatching = false
     watcher.close()
@@ -51,7 +56,7 @@ final class MdocFileListener(
 }
 
 object MdocFileListener {
-  def create(inputs: List[AbsolutePath], executor: ExecutorService, in: InputStream)(
+  def create(inputs: List[AbsolutePath], executor: ExecutorService, in: Option[InputStream])(
       runAction: DirectoryChangeEvent => Unit
   ): MdocFileListener = {
     val listener = new MdocFileListener(executor, in, runAction)


### PR DESCRIPTION
Resolves #737

This does a couple of things.

The first is to add a `--background` setting which stops mdoc from reading from standard input and waiting for the enter key and instead it blocks until being interrupted. See the first two commits for this.

The last commit wraps this up in a useful sbt tasks for starting and stopping which takes care of some non-trivial stuff like tracking the job handle.