### PR TITLE
Scala.js linker should not be `Provided`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ def scala2Versions = List(scala212, scala213)
 def allScalaVersions = scala2Versions :+ scala3
 
 // This will work as long as mdoc has scala-js SBT plugin
-def scalajs = MdocPlugin.detectScalaJSVersion
 def scalajsBinaryVersion = "1"
 def scalajsDom = "2.0.0"
 
@@ -425,7 +424,7 @@ lazy val jsWorker =
     .settings(
       sharedSettings,
       moduleName := "mdoc-js-worker",
-      libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalajs % Provided) cross CrossVersion.for3Use2_13
+      libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalaJSVersion) cross CrossVersion.for3Use2_13
     )
 
 lazy val js = project
@@ -477,7 +476,7 @@ lazy val docs = project
         "VERSION" -> stableVersion,
         "SCALA_BINARY_VERSION" -> scalaBinaryVersion.value,
         "SCALA_VERSION" -> scalaVersion.value,
-        "SCALAJS_VERSION" -> scalajs,
+        "SCALAJS_VERSION" -> scalaJSVersion,
         "SCALAJS_BINARY_VERSION" -> scalajsBinaryVersion,
         "SCALAJS_DOM_VERSION" -> scalajsDom
       )

--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -159,7 +159,7 @@ object MdocPlugin extends AutoPlugin {
           MdocJSConfiguration(
             scalacOptions = options.options,
             compileClasspath = options.classpath,
-            linkerClassPath = getJars(linkerDependency) ++ workerClasspath,
+            linkerClassPath = workerClasspath,
             moduleKind = options.moduleKind,
             jsLibraries = libraries
           ).writeTo(props)


### PR DESCRIPTION
Following from discussion in https://github.com/scalameta/mdoc/issues/740#issuecomment-1405446800.

We should hard-code the linker version used in mdoc.js, instead of having it be `Provided` by the user. So long as this linker minor version is the same or newer than the Scala.js version of the user, it should work.

_However_, now that I write this, I realize it means that mdoc would have to re-release every time Scala.js releases. That's annoying 🤔 we should try to avoid that.

So maybe we should always use the newest Scala.js version, which is either the user's version, or the version that mdoc was last built against 🤔 