### PR TITLE
Use latest known SJS version in mdoc.js, update to SJS 1.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ def scala3 = "3.1.3"
 def scala2Versions = List(scala212, scala213)
 def allScalaVersions = scala2Versions :+ scala3
 
-// This will work as long as mdoc has scala-js SBT plugin
-def scalajs = MdocPlugin.detectScalaJSVersion
 def scalajsBinaryVersion = "1"
 def scalajsDom = "2.0.0"
 
@@ -217,7 +215,7 @@ lazy val mdoc = project
     buildInfoKeys := Seq[BuildInfoKey](
       version,
       scalaVersion,
-      scalaBinaryVersion
+      scalaBinaryVersion,
     ),
     libraryDependencies ++= crossSetting(
       scalaVersion.value,
@@ -392,6 +390,7 @@ lazy val plugin = project
         (Compile / managedResourceDirectories).value.head / "sbt-mdoc.properties"
       val props = new java.util.Properties()
       props.put("version", version.value)
+      props.put("scalaJSVersion", scalaJSVersion)
       IO.write(props, "sbt-mdoc properties", out)
       List(out)
     },
@@ -425,7 +424,7 @@ lazy val jsWorker =
     .settings(
       sharedSettings,
       moduleName := "mdoc-js-worker",
-      libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalajs % Provided) cross CrossVersion.for3Use2_13
+      libraryDependencies += ("org.scala-js" %% "scalajs-linker" % scalaJSVersion % Provided) cross CrossVersion.for3Use2_13
     )
 
 lazy val js = project
@@ -477,7 +476,7 @@ lazy val docs = project
         "VERSION" -> stableVersion,
         "SCALA_BINARY_VERSION" -> scalaBinaryVersion.value,
         "SCALA_VERSION" -> scalaVersion.value,
-        "SCALAJS_VERSION" -> scalajs,
+        "SCALAJS_VERSION" -> scalaJSVersion,
         "SCALAJS_BINARY_VERSION" -> scalajsBinaryVersion,
         "SCALAJS_DOM_VERSION" -> scalajsDom
       )

--- a/build.sbt
+++ b/build.sbt
@@ -215,7 +215,7 @@ lazy val mdoc = project
     buildInfoKeys := Seq[BuildInfoKey](
       version,
       scalaVersion,
-      scalaBinaryVersion,
+      scalaBinaryVersion
     ),
     libraryDependencies ++= crossSetting(
       scalaVersion.value,

--- a/mdoc-js-worker/src/main/scala/ScalaJSWorker.scala
+++ b/mdoc-js-worker/src/main/scala/ScalaJSWorker.scala
@@ -2,6 +2,7 @@ package mdoc.js.worker;
 
 import mdoc.js.interfaces._
 import java.nio.file.Path
+import org.scalajs.ir
 import org.scalajs.linker.MemOutputDirectory
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalajs.linker.StandardImpl
@@ -86,7 +87,7 @@ class ScalaJSWorker(
   }
 
   override def inMemory(path: String, contents: Array[Byte]): ScalajsWorkerApi.IRFile = IFile(
-    new MemIRFileImpl(path, None, contents)
+    new MemIRFileImpl(path, ir.Version.Unversioned, contents)
   )
 
 }

--- a/mdoc-sbt/src/main/scala/mdoc/BuildInfo.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/BuildInfo.scala
@@ -7,7 +7,7 @@ object BuildInfo {
     props.getProperty("version", "0.8.0-SNAPSHOT")
 
   def scalaJSVersion: String =
-    props.getProperty("scalaJSVersion", "1.12.0")
+    props.getProperty("scalaJSVersion", "1.13.0")
 
   private lazy val props: Properties = {
     val props = new Properties()

--- a/mdoc-sbt/src/main/scala/mdoc/BuildInfo.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/BuildInfo.scala
@@ -6,6 +6,9 @@ object BuildInfo {
   def version: String =
     props.getProperty("version", "0.8.0-SNAPSHOT")
 
+  def scalaJSVersion: String =
+    props.getProperty("scalaJSVersion", "1.12.0")
+
   private lazy val props: Properties = {
     val props = new Properties()
     val path = "sbt-mdoc.properties"

--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -142,7 +142,15 @@ object MdocPlugin extends AutoPlugin {
         val workerClasspathOverride = mdocJSWorkerClasspath.value
 
         mdocJSCompileOptions.value.foreach { options =>
-          val sjsVersion = detectScalaJSVersion
+          val userSJSVersion = detectScalaJSVersion
+          val mdocSJSVersion = BuildInfo.scalaJSVersion
+          val sjsVersion =
+            (VersionNumber(userSJSVersion)._2, VersionNumber(mdocSJSVersion)._2) match {
+              case (Some(userSJSMinor), Some(mdocSJSMinor)) =>
+                if (userSJSMinor > mdocSJSMinor) userSJSVersion
+                else mdocSJSVersion
+              case _ => mdocSJSVersion // fallback for this unlikely case
+            }
 
           val linkerDependency = binaryVersion match {
             case "3" => "org.scala-js" % "scalajs-linker_2.13" % sjsVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")
 
 libraryDependencies ++= List(

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -298,7 +298,7 @@ class JsSuite extends BaseMarkdownSuite {
         """
           |error:
           |no-dom.md:3 (mdoc generated code)
-          | value scalajs is not a member of org
+          | value dom is not a member of org.scalajs
           |def run0(node: _root_.org.scalajs.dom.html.Element): Unit = {
       """.stripMargin
     )

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -282,9 +282,9 @@ class JsSuite extends BaseMarkdownSuite {
       |println(jsdocs.ExampleJS.greeting)
       |```
     """.stripMargin,
-    """|error: no-dom.md:4 (mdoc generated code) object scalajs is not a member of package org
+    """|error: no-dom.md:4 (mdoc generated code) object dom is not a member of package org.scalajs
        |def run0(node: _root_.org.scalajs.dom.html.Element): Unit = {
-       |                          ^
+       |                                  ^
     """.stripMargin,
     settings = {
       val noScalajsDom = Classpath(baseSettings.site("js-classpath")).entries


### PR DESCRIPTION
This changes mdoc.js to always use the latest known Scala.js version. This is sourced from the user SJS version and the SJS version that mdoc was compiled against. A newer linker should always be able to handle older SJSIR files. Meanwhile so long as mdoc is compiled against an API binary-compatible with the latest SJS linker API, it should continue working.

Closes https://github.com/scalameta/mdoc/issues/740.