### PR TITLE
chore: Update tested Scala versions to the latest available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - "'++2.12.12! test'"
           - "'++2.12.17 test'"
           - "'++2.13.10 test'"
+          # Minimal supported version
           - "'++3.1.3 test'"
           - "scripted"
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import scala.collection.mutable
 
 def scala212 = "2.12.17"
 def scala213 = "2.13.10"
+/* This should be kept at 3.1.3 until there is a
+ * need for change and in that case we should bump to LTS*/
 def scala3 = "3.1.3"
 def scala2Versions = List(scala212, scala213)
 def allScalaVersions = scala2Versions :+ scala3

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / scalaVersion := "2.12.17"
-ThisBuild / crossScalaVersions := List("2.12.17", "2.13.10", "3.1.3", "3.2.0", "3.2.1-RC1")
+ThisBuild / crossScalaVersions := List("2.12.17", "2.13.10", "3.1.3", "3.2.2")
 
 enablePlugins(MdocPlugin)
 mdocJS := Some(jsapp)

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/basic/test
@@ -4,9 +4,7 @@
 > check
 > ++3.1.3 mdoc
 > check
-> ++3.2.0 mdoc
-> check
-> ++3.2.1-RC1 mdoc
+> ++3.2.2 mdoc
 > check
 > set mdocIn := (ThisBuild / baseDirectory).value
 -> mdoc

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/scalajs-1.7/test
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/scalajs-1.7/test
@@ -4,5 +4,7 @@
 > check
 > ++3.1.3 mdoc
 > check
+> ++3.2.2 mdoc
+> check
 > set mdocIn := (ThisBuild / baseDirectory).value
 -> mdoc


### PR DESCRIPTION
The release version should staty at 3.1.x until it's there is no way but to update.