### PR TITLE
Change yarn to yarn.cmd on Windows

### DIFF
--- a/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
@@ -89,6 +89,10 @@ object DocusaurusPlugin extends AutoPlugin {
        |call yarn publish-gh-pages
     """.stripMargin
 
+  lazy val yarnBin =
+    if (scala.util.Properties.isWin) "yarn.cmd"
+    else "yarn"
+
   override def projectSettings: Seq[Def.Setting[_]] =
     List(
       aggregate.in(docusaurusPublishGhpages) := false,
@@ -121,8 +125,8 @@ object DocusaurusPlugin extends AutoPlugin {
       },
       docusaurusCreateSite := {
         m.mdoc.in(Compile).toTask(" ").value
-        Process(List("yarn", "install"), cwd = website.value).execute()
-        Process(List("yarn", "run", "build"), cwd = website.value).execute()
+        Process(List(yarnBin, "install"), cwd = website.value).execute()
+        Process(List(yarnBin, "run", "build"), cwd = website.value).execute()
         val redirectUrl = docusaurusProjectName.value + "/index.html"
         val html = redirectHtml(redirectUrl)
         val out = website.value / "build"


### PR DESCRIPTION
Fix #792 

I also checked the recommended way to install yarn (via `corepack`) and the situation is the same: a `yarn` file for Unix and a `yarn.cmd` file for windows (there's also a `yarn.ps1` file, but using the cmd seems safer).

I tested locally on my Windows machine and the problem seems to be fixed. I haven't tested this in any Unix machine, however.