### PR TITLE
improvement: Release interfaces with Java 8 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,9 +144,9 @@ lazy val interfaces = project
     Compile / doc / javacOptions ++= List(
       "-tag",
       "implNote:a:Implementation Note:"
-    )
+    ),
+    javacOptions ++= Seq("--release", "8")
   )
-  .settings(sharedJavaSettings)
 
 lazy val runtime = project
   .settings(


### PR DESCRIPTION
This allows us to use the newest version of mdoc in Metals, but we can still fall back to an older version behind the interfaces that supports an older java version

Needed for https://github.com/scalameta/metals/pull/5823