### PR TITLE
Update handling of end-of-line single-line comments

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -207,7 +207,7 @@ object Renderer {
                 section.mod
               )
               sb.append(printer(variable))
-          } 
+          }
         }
         sb.append(footer)
     }

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -2,7 +2,6 @@ package mdoc.internal.markdown
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import java.util.regex.Pattern
 import mdoc.Reporter
 import mdoc.Variable
 import mdoc.document.CompileResult
@@ -118,26 +117,15 @@ object Renderer {
           case None =>
             (Position.Range(input, 0, pos.start).text, "")
           case Some(previousStatement) =>
-            val betweenStatements =
-              section.source.pos.text.substring(previousStatement.pos.end, pos.start)
             val Array(prevTrailingSingleLineComment, leadingTrivia) =
-              betweenStatements.split(Pattern.quote("\n"), 2)
-            val footerAtEnd = {
+              section.source.pos.text.substring(previousStatement.pos.end, pos.start).split("\n", 2)
+            val foot =
               if (statementIndex != (totalStats - 1)) ""
-              else section.source.pos.text.substring(pos.end)
-            }
-            val lead =
-              // if no trailing single-line comments, then we can use the established `Position.Range` system
-              if (prevTrailingSingleLineComment.length == 0)
-                Position.Range(input, previousStatement.pos.end, pos.start).text
-              else "\n" + leadingTrivia
-            val footer = footerAtEnd.split(Pattern.quote("\n")).drop(1)
-            if (footer.nonEmpty)
-              (lead, footer.mkString("\n", "\n", ""))
-            else (lead, "")
+              else section.source.pos.text.substring(pos.end).split("\n").drop(1).mkString("\n", "\n", "")
+            ("\n" + leadingTrivia, foot)
         }
         if (!section.mod.isFailOrWarn) {
-          sb.append(leading )
+          sb.append(leading)
         }
         val endOfLinePosition =
           Position.Range(pos.input, pos.startLine, pos.startColumn, pos.endLine, Int.MaxValue)

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -211,6 +211,8 @@ class DefaultSuite extends BaseMarkdownSuite {
       |val (a, b) = Future.successful(Try(1)) -> 2
       |
       |Future.successful(Try(1))
+      |
+      |// penultimate
       |```
     """.stripMargin,
     """|```scala
@@ -226,6 +228,8 @@ class DefaultSuite extends BaseMarkdownSuite {
        |
        |Future.successful(Try(1))
        |// res1: Future[Try[Int]] = Future(Success(Success(1)))
+       |
+       |// penultimate
        |```
     """.stripMargin
   )
@@ -272,7 +276,8 @@ class DefaultSuite extends BaseMarkdownSuite {
       |
       |/** Docstring */
       |class User()
-      |```
+      |
+      |// ultimate```
     """.stripMargin,
     """|```scala
        |/* Comment 1 */
@@ -290,7 +295,8 @@ class DefaultSuite extends BaseMarkdownSuite {
        |
        |/** Docstring */
        |class User()
-       |```
+       |
+       |// ultimate```
     """.stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/DefaultSuite.scala
@@ -210,7 +210,7 @@ class DefaultSuite extends BaseMarkdownSuite {
       |Future.successful(Try(1))
       |val (a, b) = Future.successful(Try(1)) -> 2
       |
-      |Future.successful(Try(1))
+      |Future.successful(Try(1)) // last statement
       |
       |// penultimate
       |```
@@ -226,7 +226,7 @@ class DefaultSuite extends BaseMarkdownSuite {
        |// a: Future[Try[Int]] = Future(Success(Success(1)))
        |// b: Int = 2
        |
-       |Future.successful(Try(1))
+       |Future.successful(Try(1)) // last statement
        |// res1: Future[Try[Int]] = Future(Success(Success(1)))
        |
        |// penultimate
@@ -275,7 +275,7 @@ class DefaultSuite extends BaseMarkdownSuite {
       |x + y
       |
       |/** Docstring */
-      |class User()
+      |class User() // Comment 5
       |
       |// ultimate```
     """.stripMargin,
@@ -294,7 +294,7 @@ class DefaultSuite extends BaseMarkdownSuite {
        |// res0: Int = 4
        |
        |/** Docstring */
-       |class User()
+       |class User() // Comment 5
        |
        |// ultimate```
     """.stripMargin

--- a/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
@@ -7,15 +7,15 @@ class VariablePrinterSuite extends BaseMarkdownSuite {
     "single-line-comment",
     """
       |```scala mdoc
-      |import scala.None // an import statement
-      |val a = None // a variable
+      |import scala.Int // an import statement
+      |val a: Int = 1 // a variable
       |val b = 2 // another variable
       |```
     """.stripMargin,
     """|```scala
-       |import scala.None // an import statement
-       |val a = None // a variable
-       |// a: None.type = None
+       |import scala.Int // an import statement
+       |val a: Int = 1 // a variable
+       |// a: Int = 1
        |val b = 2 // another variable
        |// b: Int = 2
        |```

--- a/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
@@ -3,6 +3,44 @@ import mdoc.internal.markdown.ReplVariablePrinter
 
 class VariablePrinterSuite extends BaseMarkdownSuite {
 
+  check(
+    "single-line-comment",
+    """
+      |```scala mdoc
+      |import scala.Some // an import statement
+      |val a = Some(1) // a variable
+      |val b = 2 // another variable
+      |```
+    """.stripMargin,
+    """|```scala
+       |import scala.Some // an import statement
+       |val a = Some(1) // a variable
+       |// a: Some[Int] = Some(value = 1)
+       |val b = 2 // another variable
+       |// b: Int = 2
+       |```
+    """.stripMargin,
+    baseSettings
+  )
+
+  check(
+    "single-line-comment:compile-only",
+    """|```scala mdoc:compile-only
+       |// a
+       |val a = 10
+       |val b = 20 // b
+       |val c = 30
+       |```""".stripMargin,
+    """|```scala
+       |// a
+       |val a = 10
+       |val b = 20 // b
+       |val c = 30
+       |```
+    """.stripMargin,
+    baseSettings
+  )
+
   val trailingComment = baseSettings.copy(variablePrinter = { variable =>
     variable.runtimeValue match {
       case n: Int if variable.totalVariablesInStatement == 1 => s" // Number($n)"
@@ -10,7 +48,7 @@ class VariablePrinterSuite extends BaseMarkdownSuite {
     }
   })
 
-  check(
+    check(
     "trailing-comment",
     """
       |```scala mdoc

--- a/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
@@ -48,7 +48,7 @@ class VariablePrinterSuite extends BaseMarkdownSuite {
     }
   })
 
-    check(
+  check(
     "trailing-comment",
     """
       |```scala mdoc

--- a/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
+++ b/tests/unit/src/test/scala/tests/markdown/VariablePrinterSuite.scala
@@ -7,15 +7,15 @@ class VariablePrinterSuite extends BaseMarkdownSuite {
     "single-line-comment",
     """
       |```scala mdoc
-      |import scala.Some // an import statement
-      |val a = Some(1) // a variable
+      |import scala.None // an import statement
+      |val a = None // a variable
       |val b = 2 // another variable
       |```
     """.stripMargin,
     """|```scala
-       |import scala.Some // an import statement
-       |val a = Some(1) // a variable
-       |// a: Some[Int] = Some(value = 1)
+       |import scala.None // an import statement
+       |val a = None // a variable
+       |// a: None.type = None
        |val b = 2 // another variable
        |// b: Int = 2
        |```


### PR DESCRIPTION
Fix for #321, #605 🎄🎁

> Adopted solution: distinguish between leading trivia a) previous trailing trivia, b) current leading trivia, c) a footer in case of last statement.

Hello,

It's really fun slowly discovering all that mdoc can do. However, I finally ran into the comment duplication issue (for me, import statements). Following the threads from previous comments (in the issues linked above), I propose the changes in this PR:
 - Update the `Render.renderEvaluatedSection` method to more explicitly handle these types of comments
 - Add unit tests for common cases
 - Add code comments in case of further enhancement or refinement
 
What other strategies did I consider but reject?
 - Add support for comments to the `stats` and `Range.Position` systems: my (possibly incorrect) impression is that the root cause is the lack of comments in quasiquotes, and, since adding them is out of scope, that therefore some workarounds are required
 - Add an explicit model of the source (with trivia) in a code fence: prefer to trial this PR, defer solidifying/polishing up case classes, optional fields, etc.

Happy to make changes as needed, and thanks for your consideration.

