### PR TITLE
EvaluatedMarkdownDocument interface

### DIFF
--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedMarkdownDocument.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/EvaluatedMarkdownDocument.java
@@ -1,0 +1,13 @@
+package mdoc.interfaces;
+
+import java.util.List;
+import java.nio.file.Path;
+import coursierapi.Dependency;
+import coursierapi.Repository;
+
+public abstract class EvaluatedMarkdownDocument {
+
+	public abstract List<Diagnostic> diagnostics();
+
+	public abstract String content();
+}

--- a/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
+++ b/mdoc-interfaces/src/main/scala/mdoc/interfaces/Mdoc.java
@@ -1,11 +1,12 @@
 package mdoc.interfaces;
 
 import java.util.List;
+import java.util.Map;
 import java.nio.file.Path;
 import java.io.PrintStream;
 
 public abstract class Mdoc {
-
+  public abstract EvaluatedMarkdownDocument evaluateMarkdownDocument(String filename, String text, Map<String, String> variables);
   public abstract EvaluatedWorksheet evaluateWorksheet(String filename, String text);
   public abstract EvaluatedWorksheet evaluateWorksheet(String filename, String text, String modifier);
   public abstract Mdoc withWorkingDirectory(Path workingDirectory);

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -168,7 +168,7 @@ object Instrumenter {
 
   def stringLiteral(string: String): String = {
     import scala.meta.internal.prettyprinters._
-    DoubleQuotes(string)
+    enquote(string, DoubleQuotes)
   }
 
   def wrapBody(body: String): String = {

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -168,7 +168,7 @@ object Instrumenter {
 
   def stringLiteral(string: String): String = {
     import scala.meta.internal.prettyprinters._
-    enquote(string, DoubleQuotes)
+    DoubleQuotes(string)
   }
 
   def wrapBody(body: String): String = {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/EvaluatedMarkdownDocument.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/EvaluatedMarkdownDocument.scala
@@ -1,0 +1,10 @@
+package mdoc.internal.markdown
+
+import java.{util => ju}
+import mdoc.{interfaces => i}
+import java.nio.file.Path
+
+case class EvaluatedMarkdownDocument(
+    val diagnostics: ju.List[i.Diagnostic],
+    val content: String
+) extends mdoc.interfaces.EvaluatedMarkdownDocument

--- a/tests/worksheets/src/test/scala/tests/worksheets/EvaluatedMarkdownDocumentSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/EvaluatedMarkdownDocumentSuite.scala
@@ -62,7 +62,9 @@ class EvaluatedMarkdownDocumentSuite extends BaseSuite {
         |```
       """.stripMargin
 
-    val variables = java.util.Map.of("HELLO", "1", "WORLD", "2")
+    val variables = new java.util.HashMap[String, String]()
+    variables.put("HELLO", "1")
+    variables.put("WORLD", "2")
 
     val evaluated = mdoc.evaluateMarkdownDocument("README.md", document, variables)
 

--- a/tests/worksheets/src/test/scala/tests/worksheets/EvaluatedMarkdownDocumentSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/EvaluatedMarkdownDocumentSuite.scala
@@ -1,0 +1,71 @@
+package tests.interface
+
+import mdoc.interfaces.DiagnosticSeverity
+import mdoc.interfaces.Mdoc
+import mdoc.internal.CompatClassloader
+import mdoc.internal.pos.PositionSyntax._
+import munit.Location
+import munit.TestOptions
+import tests.BaseSuite
+import tests.markdown.Compat
+
+import java.lang.StringBuilder
+import java.nio.file.Paths
+import java.{util => ju}
+import scala.meta.inputs.Input
+import scala.meta.inputs.Position
+
+class EvaluatedMarkdownDocumentSuite extends BaseSuite {
+
+  var mdoc = ju.ServiceLoader
+    .load(classOf[Mdoc], this.getClass().getClassLoader())
+    .iterator()
+    .next()
+    .withScreenHeight(5)
+    .withClasspath(
+      CompatClassloader
+        .getURLs(this.getClass().getClassLoader())
+        .collect {
+          case url
+              if url.toString.contains("scala3-library") || url.toString
+                .contains("scala-library") =>
+            Paths.get(url.toURI())
+        }
+        .asJava
+    )
+
+  override def afterAll(): Unit = {
+    mdoc.shutdown()
+  }
+
+  test("basic markdown evaluation") {
+    val document =
+      """
+        |# Hello world!
+        | 
+        |The latest library version is `@HELLO@.@WORLD@`
+        | 
+        |```scala mdoc
+        |println(math.abs(-25))
+        |```
+      """.stripMargin
+
+    val expectedContent =
+      """
+        |# Hello world!
+        | 
+        |The latest library version is `1.2`
+        | 
+        |```scala
+        |println(math.abs(-25))
+        |// 25
+        |```
+      """.stripMargin
+
+    val variables = java.util.Map.of("HELLO", "1", "WORLD", "2")
+
+    val evaluated = mdoc.evaluateMarkdownDocument("README.md", document, variables)
+
+    assertEquals(evaluated.content(), expectedContent)
+  }
+}


### PR DESCRIPTION
This is a proposal to discuss with other maintainers.

Adding this method allows managing multiple mdoc instance via classloaders, and in general makes the Mdoc interface cover the thing _most_ people would use mdoc for - markdown documents.

I've already confirmed that with this PR it's possible to use mdoc through a filtering classloader to render markdown documents, even with custom classpath.

cc @tgodzik @olafurpg @ckipp01 