### PR TITLE
bugfix: Calculate string value eagerly

### DIFF
--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -1,23 +1,24 @@
 package mdoc.internal.markdown
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import mdoc.Reporter
 import mdoc.Variable
 import mdoc.document.CompileResult
 import mdoc.document.CrashResult
 import mdoc.document.CrashResult.Crashed
 import mdoc.document.RangePosition
+import mdoc.internal.cli.Context
+import mdoc.internal.cli.InputFile
+import mdoc.internal.cli.Settings
 import mdoc.internal.document.FailSection
 import mdoc.internal.document.MdocExceptions
 import mdoc.internal.document.Printing
 import mdoc.internal.pos.PositionSyntax._
 import mdoc.internal.pos.TokenEditDistance
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import scala.meta._
 import scala.meta.inputs.Position
-import mdoc.internal.cli.InputFile
-import mdoc.internal.cli.Settings
-import mdoc.internal.cli.Context
 
 object Renderer {
 
@@ -172,7 +173,7 @@ object Renderer {
                   }
                   appendFreshMultiline(sb, compiled)
                 case _ =>
-                  val obtained = Printing.stringValue(binder.value)
+                  val obtained = binder.stringValue
                   throw new IllegalArgumentException(
                     s"Expected FailSection. Obtained $obtained"
                   )

--- a/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
+++ b/mdoc/src/main/scala/mdoc/internal/worksheets/WorksheetProvider.scala
@@ -1,20 +1,21 @@
 package mdoc.internal.worksheets
 
-import scala.meta._
-import mdoc.internal.pos.PositionSyntax._
+import mdoc.document.RangePosition
+import mdoc.document.Statement
 import mdoc.internal.cli.Context
-import mdoc.internal.markdown.SectionInput
-import mdoc.internal.markdown.Modifier
+import mdoc.internal.cli.InputFile
+import mdoc.internal.cli.Settings
+import mdoc.internal.document.Printing
+import mdoc.internal.io.StoreReporter
 import mdoc.internal.markdown.Instrumenter
 import mdoc.internal.markdown.MarkdownBuilder
-import mdoc.internal.document.Printing
-import mdoc.document.Statement
-import mdoc.document.RangePosition
-import mdoc.internal.cli.Settings
-import mdoc.internal.io.StoreReporter
+import mdoc.internal.markdown.Modifier
+import mdoc.internal.markdown.SectionInput
+import mdoc.internal.pos.PositionSyntax._
 import mdoc.{interfaces => i}
+
 import java.{util => ju}
-import mdoc.internal.cli.InputFile
+import scala.meta._
 
 class WorksheetProvider(settings: Settings) {
 
@@ -93,7 +94,7 @@ class WorksheetProvider(settings: Settings) {
           .append(": ")
           .append(binder.tpeString)
           .append(" = ")
-        Printing.print(binder.value, out, settings.screenWidth, settings.screenHeight)
+        Printing.print(binder.stringValue, out, settings.screenWidth, settings.screenHeight)
       }
     }
     statement.out.linesIterator.foreach { line =>
@@ -138,7 +139,7 @@ class WorksheetProvider(settings: Settings) {
                 .append(binder.tpeString)
                 .append(" = ")
 
-            Printing.printOneLine(binder.value, out, width = margin - out.length)
+            Printing.printOneLine(binder.stringValue, out, width = margin - out.length)
             out.length > margin
         }
       }

--- a/runtime/src/main/scala/mdoc/document/Binder.scala
+++ b/runtime/src/main/scala/mdoc/document/Binder.scala
@@ -1,10 +1,13 @@
 package mdoc.document
 
-import mdoc.internal.sourcecode.SourceStatement
-import mdoc.internal.document.Printing
 import mdoc.internal.document.Compat.TPrint
+import mdoc.internal.document.Printing
+import mdoc.internal.sourcecode.SourceStatement
 
 final class Binder[T](val value: T, val name: String, val tpe: TPrint[T], val pos: RangePosition) {
+
+  val stringValue = Printing.stringValue(value)
+
   override def toString: String = {
     val valueString = Printing.stringValue(value)
     s"""Binder($valueString, "$name", "$tpeString")"""

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -51,6 +51,27 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
+    "updates",
+    """
+      |import scala.collection.mutable.ArrayBuffer
+      |val b = ArrayBuffer[Int]()
+      |b += 1
+      |b ++= ArrayBuffer(5, 8, 12)
+      |b.dropRight(3)
+      |""".stripMargin,
+    """|import scala.collection.mutable.ArrayBuffer
+       |<val b = ArrayBuffer[Int]()> // : ArrayBuffer[Int] =...
+       |b: ArrayBuffer[Int] = ArrayBuffer()
+       |<b += 1> // : ArrayBuffer[Int] = Arr...
+       |res0: ArrayBuffer[Int] = ArrayBuffer(1)
+       |<b ++= ArrayBuffer(5, 8, 12)> // : ArrayBuffer[Int] =...
+       |res1: ArrayBuffer[Int] = ArrayBuffer(1, 5, 8, 12)
+       |<b.dropRight(3)> // : ArrayBuffer[Int] =...
+       |res2: ArrayBuffer[Int] = ArrayBuffer(1)
+       |""".stripMargin
+  )
+
+  checkDecorations(
     "infix",
     """|import scala.language.postfixOps
        |42 toString


### PR DESCRIPTION
Previously, we would stringify everything at the end, which means any mutable collections etc would be printed wrongly.

Now, we caluclate string value eagerly.

Related to https://github.com/scalameta/metals/issues/6500