### PR TITLE
improvement: Print array contents instead of toString

### DIFF
--- a/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
+++ b/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
@@ -14,9 +14,9 @@ object Printing {
     out.append(nullableToString(value).replace("\n", ""))
   }
 
-  inline private def nullableToString[T](value: T) = {
+  private def nullableToString[T](value: T): String = {
     value match
-      case arr: Array[_] => arr.mkString("Array(", ", ", ")")
+      case arr: Array[_] => arr.map(nullableToString).mkString("Array(", ", ", ")")
       case null => "null"
       case _ => value.toString()
   }

--- a/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
+++ b/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
@@ -15,6 +15,9 @@ object Printing {
   }
 
   inline private def nullableToString[T](value: T) = {
-    if (value != null) value.toString else "null"
+    value match
+      case arr: Array[_] => arr.mkString("Array(", ", ", ")")
+      case null => "null"
+      case _ => value.toString()
   }
 }

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -76,11 +76,14 @@ class WorksheetSuite extends BaseSuite {
     """
       |val x = Array(1, 2, 3)
       |val y = Array("a", "b")
+      |val arrays = Array(Array(1, 2, 3), Array(2, 3, 4))
       |""".stripMargin,
     """|<val x = Array(1, 2, 3)> // : Array[Int] = Array...
        |x: Array[Int] = Array(1, 2, 3)
        |<val y = Array("a", "b")> // : Array[String] = Ar...
        |y: Array[String] = Array("a", "b")
+       |<val arrays = Array(Array(1, 2, 3), Array(2, 3, 4))> // : Array[Array[Int]] ...
+       |arrays: Array[Array[Int]] = Array(Array(1, 2, 3), Array(2, 3, 4))
        |""".stripMargin,
     compat = Map(
       Compat.Scala3 ->
@@ -88,6 +91,8 @@ class WorksheetSuite extends BaseSuite {
            |x: Array[Int] = Array(1, 2, 3)
            |<val y = Array("a", "b")> // : Array[String] = Ar...
            |y: Array[String] = Array(a, b)
+           |<val arrays = Array(Array(1, 2, 3), Array(2, 3, 4))> // : Array[Array[Int]] ...
+           |arrays: Array[Array[Int]] = Array(Array(1, 2, 3), Array(2, 3, 4))
            |""".stripMargin
     )
   )

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -72,6 +72,27 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
+    "arrays",
+    """
+      |val x = Array(1, 2, 3)
+      |val y = Array("a", "b")
+      |""".stripMargin,
+    """|<val x = Array(1, 2, 3)> // : Array[Int] = Array...
+       |x: Array[Int] = Array(1, 2, 3)
+       |<val y = Array("a", "b")> // : Array[String] = Ar...
+       |y: Array[String] = Array("a", "b")
+       |""".stripMargin,
+    compat = Map(
+      Compat.Scala3 ->
+        """|<val x = Array(1, 2, 3)> // : Array[Int] = Array...
+           |x: Array[Int] = Array(1, 2, 3)
+           |<val y = Array("a", "b")> // : Array[String] = Ar...
+           |y: Array[String] = Array(a, b)
+           |""".stripMargin
+    )
+  )
+
+  checkDecorations(
     "infix",
     """|import scala.language.postfixOps
        |42 toString


### PR DESCRIPTION
Martin was adamant that we should always use toString instead of pprint which we use for Scala 2, but for Arrays it is quite useless and it seems REPL is also printing contents.

Related to https://github.com/scalameta/metals/issues/6499