### PR TITLE
bugfix: Remove additional whitespace from summary

### DIFF
--- a/runtime/src/main/scala-2/mdoc/internal/document/Printing.scala
+++ b/runtime/src/main/scala-2/mdoc/internal/document/Printing.scala
@@ -1,8 +1,10 @@
 package mdoc.internal.document
 
-import pprint.TPrintColors
-import pprint.PPrinter.BlackWhite
+import fansi.Str
 import pprint.PPrinter
+import pprint.PPrinter.BlackWhite
+import pprint.TPrintColors
+
 import Compat.TPrint
 
 object Printing {
@@ -15,17 +17,8 @@ object Printing {
       .foreach(text => out.appendAll(text.getChars))
   }
 
-  def printOneLine[T](value: T, out: StringBuilder, width: Int) = {
-    val chunk = BlackWhite
-      .tokenize(value, width)
-      .map(_.getChars)
-      .filterNot(_.iterator.forall(_.isWhitespace))
-      .flatMap(_.iterator)
-      .filter {
-        case '\n' => false
-        case _ => true
-      }
-    out.appendAll(chunk)
-
+  def printOneLine(value: Str, out: StringBuilder, width: Int) = {
+    out.appendAll(value.toString().replace("\n", " ").replaceAll("\\s+", " ")).take(width + 1)
   }
+
 }

--- a/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
+++ b/runtime/src/main/scala-3/mdoc/internal/document/Printing.scala
@@ -11,7 +11,7 @@ object Printing {
   }
 
   inline def printOneLine[T](value: T, out: StringBuilder, width: Int) = {
-    out.append(nullableToString(value).replace("\n", ""))
+    out.append(nullableToString(value).replace("\n", "").replaceAll("\\s+", " "))
   }
 
   private def nullableToString[T](value: T): String = {


### PR DESCRIPTION
The recent changes caused the spaces to no longer be removed properly due to the fact that we no longer operate on an actual value when printing one line summary.
    
I tried solving this multiple ways but:
    - there is no sensible way to just copy any value
    - using pprint.Tree as intermediate representation doesn't work as those contain Iterator and are one use only
    
The easiest approach was to just replace newline with space and then deduplicate whitespace to save space on the oneline summary. This also makes it consistent across Scala 2 and 3