### PR TITLE
Upgrade undertow, report dependencies to GitHub

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,13 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sbt/setup-sbt@v1
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,7 @@ lazy val mdoc = project
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "io.methvin" % "directory-watcher" % "0.18.0",
       // live reload
-      "io.undertow" % "undertow-core" % "2.2.24.Final",
+      "io.undertow" % "undertow-core" % "2.2.30.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.16.Final",
       "org.slf4j" % "slf4j-api" % "2.0.16",
       "org.scalameta" %% "metaconfig-typesafe-config" % V.metaconfig,


### PR DESCRIPTION
Undertow < 2.2.30.Final has multiple security alerts (e.g. https://github.com/zio/zio-streams-compress/security/dependabot/14). This upgrades Undertow to the fixed version.

Also add a workflow for reporting the dependencies to GitHub, allowing security warnings from GitHub.

As described on https://github.com/marketplace/actions/sbt-dependency-submission, before running the workflow, make sure that the `Dependency Graph` feature is enabled in the settings of your repository (`Settings` > `Code Security and Analysis`). 
The graph of your sbt build will be visible in the [Dependency Graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository) page of the `Insights` tab.
