### PR TITLE
fix: call `SourceStatement` explicitly in place of an implicit cast

### DIFF
--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -100,7 +100,7 @@ class Instrumenter(
   }
 
   private def printBinder(name: String, pos: Position): Unit = {
-    sb.print(s"; $$doc.binder($name, ${position(pos)})")
+    sb.print(s"; $$doc.binder(mdoc.internal.sourcecode.SourceStatement($name), ${position(pos)})")
   }
   private def printStatement(stat: Tree, m: Modifier, sb: PrintStream): Unit = {
     if (!m.isCrash) {

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -97,7 +97,7 @@ class Instrumenter(
   }
 
   private def printBinder(name: String, pos: Position): Unit = {
-    sb.println(s"$$doc.binder($name, ${position(pos)});")
+    sb.println(s"$$doc.binder(mdoc.internal.sourcecode.SourceStatement($name), ${position(pos)});")
   }
   private def printStatement(stat: Tree, m: Modifier, sb: CodePrinter): Unit = {
     if (!m.isCrash) {

--- a/runtime/src/main/scala-2/mdoc/internal/sourcecode/Macros.scala
+++ b/runtime/src/main/scala-2/mdoc/internal/sourcecode/Macros.scala
@@ -3,9 +3,7 @@ package mdoc.internal.sourcecode
 import language.experimental.macros
 
 trait StatementMacro {
-  implicit def generate[T](v: T): SourceStatement[T] = macro Macros.text[T]
   def apply[T](v: T): SourceStatement[T] = macro Macros.text[T]
-
 }
 
 object Macros {

--- a/runtime/src/main/scala-3/mdoc/internal/sourcecode/Macros.scala
+++ b/runtime/src/main/scala-3/mdoc/internal/sourcecode/Macros.scala
@@ -4,7 +4,6 @@ import scala.language.implicitConversions
 import scala.quoted._
 
 trait StatementMacro {
-  inline implicit def generate[T](v: => T): SourceStatement[T] = ${ Macros.text('v) }
   inline def apply[T](v: => T): SourceStatement[T] = ${ Macros.text('v) }
 }
 

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -600,6 +600,14 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
+  checkDecorations(
+    "metals-i7248",
+    "val myNullVal = null",
+    """|<val myNullVal = null> // : Null = null
+       |myNullVal: Null = null
+       |""".stripMargin
+  )
+
   def checkDiagnostics(
       options: TestOptions,
       original: String,


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/7248

The problem with using implicit cast was that `Null <: SourceStatement[Null]`, so for `val x: Null = null `SourceStatement.generate` was never called resulting in a `NullPointerException`.