### PR TITLE
feature: Add support for using directives

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,6 +241,7 @@ lazy val mdoc = project
     },
     libraryDependencies ++= jsoniter,
     libraryDependencies ++= List(
+      "org.virtuslab" % "using_directives" % "1.1.4",
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "io.methvin" % "directory-watcher" % "0.18.0",
       // live reload

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,0 +1,72 @@
+---
+id: directives
+title: Using Directives
+sidebar_label: Directives
+---
+
+Similar to how [Scala CLI](https://scala-cli.virtuslab.org/) works, mdoc also
+supports some directives that you can use to add additional capabilities to your
+snippets. The number of directives is reduced to a much smaller number, but they
+should work mostly the same.
+
+## Dependencies
+
+To add new dependencies use the `deps` directive. The dependencies are added to
+the classpath of the code block.
+
+````scala mdoc:mdoc
+```scala mdoc
+//> using dep com.lihaoyi::scalatags:0.13.1
+import scalatags.Text.all._
+val htmlFile = html(
+  body(
+    p("This is a big paragraph of text")
+  )
+)
+```
+````
+
+## Repositories
+
+To add new repositories use the `repos` directive. These are necessary if you
+want to use a dependency that is not in the default maven central repository.
+
+````scala mdoc:mdoc
+```scala mdoc
+//> using repo https://oss.sonatype.org/content/repositories/snapshots
+//> using dep org.scalameta:mtags_2.12.20:1.5.2+8-c4181af3-SNAPSHOT
+scala.meta.internal.mtags.BuildInfo.scalaCompilerVersion
+```
+````
+
+## Compiler Options
+
+It's also possible to add Scala compiler options to your snippets, to do that
+use the 'options' directive.
+
+````scala mdoc:mdoc:fail
+```scala mdoc:fail
+//> using option -Ywarn-unused-import -Xfatal-warnings
+import scala.util.Try
+println(42)
+```
+````
+
+## Importing files
+
+To import files into your snippets, you can use the `files` directive. This is
+useful if you want to import outside definitions from other files. The files are
+compiled and added to the classpath of the code block. Currently only `.sc` script
+files are supported.
+
+````scala mdoc:mdoc:crash
+```scala mdoc
+//> using file ../hello.sc
+println(hello.message)
+```
+````
+
+## Ammonite style imports
+
+Mdoc also support Ammonite style imports, but they are currently deprecated and
+the using directives are preferred.

--- a/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-2/mdoc/internal/markdown/Instrumenter.scala
@@ -33,6 +33,10 @@ class Instrumenter(
     )
   }
   val magic = new MagicImports(settings, reporter, file)
+  sections.foreach { section =>
+    magic.findUsingDirectives(section.input)
+    magic.visitUsingFile(section.input)
+  }
   private val out = new ByteArrayOutputStream()
   private val sb = new PrintStream(out)
   val gensym = new Gensym()

--- a/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
+++ b/mdoc/src/main/scala-3/mdoc/internal/markdown/Instrumenter.scala
@@ -31,6 +31,10 @@ class Instrumenter(
     )
   }
   val magic = new MagicImports(settings, reporter, file)
+  sections.foreach { section =>
+    magic.findUsingDirectives(section.input)
+    magic.visitUsingFile(section.input)
+  }
   private val out = new ByteArrayOutputStream()
   val gensym = new Gensym()
   val sb = new CodePrinter(new PrintStream(out))

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Instrumented.scala
@@ -15,9 +15,9 @@ import coursierapi.error.CoursierError
 
 case class Instrumented(
     source: String,
-    scalacOptionImports: List[Name.Indeterminate],
-    dependencyImports: List[Name.Indeterminate],
-    repositoryImports: List[Name.Indeterminate],
+    scalacOptionImports: List[MagicImport],
+    dependencyImports: List[MagicImport],
+    repositoryImports: List[MagicImport],
     fileImports: List[FileImport],
     positionedDependencies: List[PositionedDependency],
     dependencies: Set[Dependency],
@@ -27,13 +27,14 @@ case class Instrumented(
 object Instrumented {
   def fromSource(
       source: String,
-      scalacOptionImports: List[Name.Indeterminate],
-      dependencyImports: List[Name.Indeterminate],
-      repositoryImports: List[Name.Indeterminate],
+      scalacOptionImports: List[MagicImport],
+      dependencyImports: List[MagicImport],
+      repositoryImports: List[MagicImport],
       fileImports: List[FileImport],
       reporter: Reporter
   ): Instrumented = {
-    val positioned = dependencyImports.flatMap(i => PositionedDependency.fromName(i, reporter))
+    val positioned =
+      dependencyImports.flatMap(i => PositionedDependency.fromMagicImport(i, reporter))
     val dependencies = positioned.map(_.dep).toSet
     val repositories =
       for {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownBuilder.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/MarkdownBuilder.scala
@@ -91,6 +91,7 @@ object MarkdownBuilder {
           pathString.contains("fansi") ||
           pathString.contains("pprint") ||
           pathString.contains("mdoc-interfaces") ||
+          pathString.contains("using_directives") ||
           (pathString.contains("mdoc") && pathString.contains("runtime")) ||
           (pathString.contains("mdoc") && pathString.contains("printing"))
         })

--- a/mdoc/src/main/scala/mdoc/internal/markdown/PositionedDependency.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/PositionedDependency.scala
@@ -16,7 +16,7 @@ object PositionedDependency {
   val Full: Regex = "(.+):::(.+):(.+)".r
   val Half: Regex = "(.+)::(.+):(.+)".r
   val Java: Regex = "(.+):(.+):(.+)".r
-  def fromName(i: Name.Indeterminate, reporter: Reporter): Option[PositionedDependency] = {
+  def fromMagicImport(i: MagicImport, reporter: Reporter): Option[PositionedDependency] = {
     def create(
         org: String,
         artifact: String,

--- a/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/Renderer.scala
@@ -104,7 +104,7 @@ object Renderer {
     val stats = section.source.stats.lift
     val input = section.source.pos.input
     val totalStats = section.source.stats.length
-    if (section.mod.isFailOrWarn) {
+    if (section.mod.isFailOrWarn || section.section.statements.isEmpty) {
       sb.print(section.input.text)
     }
     section.section.statements.zip(section.source.stats).zipWithIndex.foreach {

--- a/mdoc/src/main/scala/mdoc/internal/markdown/UsingReporter.scala
+++ b/mdoc/src/main/scala/mdoc/internal/markdown/UsingReporter.scala
@@ -1,0 +1,34 @@
+package mdoc.internal.markdown
+
+import com.virtuslab.{using_directives => using}
+import mdoc.Reporter
+
+import scala.meta.inputs.Input
+
+class UsingReporter(input: Input, reporter: Reporter) extends using.reporter.Reporter {
+
+  import MagicImports._
+  override def error(msg: String): Unit = {
+    reporter.error(msg)
+  }
+
+  override def warning(msg: String): Unit = {
+
+    reporter.warning(msg)
+  }
+
+  override def error(position: using.custom.utils.Position, msg: String): Unit = {
+    reporter.error(toMetaPosition(input, position), msg)
+  }
+
+  override def warning(position: using.custom.utils.Position, msg: String): Unit = {
+    reporter.warning(toMetaPosition(input, position), msg)
+  }
+
+  override def hasErrors(): Boolean = reporter.hasErrors
+
+  override def hasWarnings(): Boolean = reporter.hasWarnings
+
+  override def reset(): Unit = reporter.reset()
+
+}

--- a/tests/unit/src/main/scala/tests/cli/StringFS.scala
+++ b/tests/unit/src/main/scala/tests/cli/StringFS.scala
@@ -39,7 +39,7 @@ object StringFS {
       charset: Charset = StandardCharsets.UTF_8
   ): AbsolutePath = {
     if (!layout.trim.isEmpty) {
-      layout.split("(?=\n/)").foreach { row =>
+      layout.split("(?=\n/(?!/))").foreach { row =>
         row.stripPrefix("\n").split("\n", 2).toList match {
           case path :: contents :: Nil =>
             val file = root.resolve(path.stripPrefix("/"))

--- a/tests/unit/src/test/scala/tests/imports/DependencySuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/DependencySuite.scala
@@ -20,17 +20,23 @@ class DependencySuite extends BaseMarkdownSuite {
       }
     )
 
-  List("dep", "ivy").foreach { dep =>
+  List(
+    "$dep" -> "import $dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._",
+    "$ivy" -> "import $ivy.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._",
+    "using-dep" -> """|//> using dep org.dhallj::dhall-scala:0.3.0
+                      |import org.dhallj.syntax._
+                      |""".stripMargin
+  ).foreach { case (name, dep) =>
     check(
-      dep.tag(OnlyScala213),
+      name.tag(OnlyScala213),
       s"""
          |```scala mdoc
-         |import $$$dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._
+         |$dep
          |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
          |```
          | """.stripMargin,
       s"""|```scala
-          |import $$$dep.`org.dhallj::dhall-scala:0.3.0`, org.dhallj.syntax._
+          |$dep
           |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
           |// res0: Either[org.dhallj.core.DhallException.ParsingFailure, org.dhallj.core.Expr] = Right(
           |//   value = λ(n : Natural) → [n + 0, n + 1, 1 + 1]
@@ -39,6 +45,27 @@ class DependencySuite extends BaseMarkdownSuite {
           |""".stripMargin
     )
   }
+
+  checkError(
+    "unknown".tag(OnlyScala213),
+    s"""
+       |```scala mdoc
+       |//> using depaa org.dhallj::dhall-scala:0.3.0
+       |import org.dhallj.syntax._
+       |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
+       |```
+       | """.stripMargin,
+    s"""|warning: unknown.md:3:11: Unknown directive: depaa
+        |//> using depaa org.dhallj::dhall-scala:0.3.0
+        |          ^
+        |error: unknown.md:4:8: object dhallj is not a member of package org
+        |import org.dhallj.syntax._
+        |       ^^^^^^^^^^
+        |error: unknown.md:5:1: value parseExpr is not a member of String
+        |"\\\\(n: Natural) -> [n + 0, n + 1, 1 + 1]".parseExpr
+        |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        |""".stripMargin
+  )
 
   check(
     "repo".tag(OnlyScala213),
@@ -58,18 +85,50 @@ class DependencySuite extends BaseMarkdownSuite {
        |""".stripMargin
   )
 
+  check(
+    "repo-using".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |//> using repo https://oss.sonatype.org/content/repositories/snapshots
+      |//> using dep org.scalameta:metals_2.13:0.11.10+1-4aa438b0-SNAPSHOT
+      |scala.meta.internal.metals.ScalaVersions.isScala3Milestone("3.0.0")
+      |```
+      | """.stripMargin,
+    """|```scala
+       |//> using repo https://oss.sonatype.org/content/repositories/snapshots
+       |//> using dep org.scalameta:metals_2.13:0.11.10+1-4aa438b0-SNAPSHOT
+       |scala.meta.internal.metals.ScalaVersions.isScala3Milestone("3.0.0")
+       |// res0: Boolean = false
+       |```
+       |""".stripMargin
+  )
+
   checkError(
-    "repo-error".tag(OnlyScala213),
+    "ammonite".tag(OnlyScala213),
     """
       |```scala mdoc
       |import $repo.`sbt-plugin:foobar`
       |println(42)
       |```
       | """.stripMargin,
-    """|error: repo-error.md:3:14: sbt-plugin repositories are not supported. Please open a feature request to discuss adding support for sbt-plugin repositories https://github.com/scalameta/mdoc/
-       |import $repo.`sbt-plugin:foobar`
-       |             ^^^^^^^^^^^^^^^^^^^
-       |""".stripMargin
+    s"""|error: ammonite.md:3:14: sbt-plugin repositories are not supported. Please open a feature request to discuss adding support for sbt-plugin repositories https://github.com/scalameta/mdoc/
+        |import $$repo.`sbt-plugin:foobar`
+        |             ^^^^^^^^^^^^^^^^^^^
+        |""".stripMargin
+  )
+
+  checkError(
+    "using".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |//> using repo sbt-plugin:foobar
+      |println(42)
+      |```
+      | """.stripMargin,
+    s"""|error: using.md:3:11: sbt-plugin repositories are not supported. Please open a feature request to discuss adding support for sbt-plugin repositories https://github.com/scalameta/mdoc/
+        |//> using repo sbt-plugin:foobar
+        |          ^
+        |""".stripMargin
   )
 
   checkError(
@@ -101,6 +160,34 @@ class DependencySuite extends BaseMarkdownSuite {
   )
 
   checkError(
+    "dep-error-using".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |//> using dep org.scalameta::mmunit:2.3.4 org.scalameta:foobar:1.2.1
+      |//> using dep org.scalameta:::not-exists:2.3.4
+      |//> using dep org.scalameta::munit:0.7.5 // resolves OK
+      |println(42)
+      |```
+      | """.stripMargin,
+    s"""|error: dep-error-using.md:4:11: Error downloading org.scalameta:not-exists_2.13.16:2.3.4
+        |<redacted user.home>
+        |  not found: https://repo1.maven.org/maven2/org/scalameta/not-exists_2.13.16/2.3.4/not-exists_2.13.16-2.3.4.pom
+        |//> using dep org.scalameta:::not-exists:2.3.4
+        |          ^
+        |error: dep-error-using.md:3:11: Error downloading org.scalameta:foobar:1.2.1
+        |<redacted user.home>
+        |  not found: https://repo1.maven.org/maven2/org/scalameta/foobar/1.2.1/foobar-1.2.1.pom
+        |//> using dep org.scalameta::mmunit:2.3.4 org.scalameta:foobar:1.2.1
+        |          ^
+        |error: dep-error-using.md:3:11: Error downloading org.scalameta:mmunit_2.13:2.3.4
+        |<redacted user.home>
+        |  not found: https://repo1.maven.org/maven2/org/scalameta/mmunit_2.13/2.3.4/mmunit_2.13-2.3.4.pom
+        |//> using dep org.scalameta::mmunit:2.3.4 org.scalameta:foobar:1.2.1
+        |          ^
+        |""".stripMargin
+  )
+
+  checkError(
     "dep-syntax-error".tag(OnlyScala213),
     """
       |```scala mdoc
@@ -112,6 +199,21 @@ class DependencySuite extends BaseMarkdownSuite {
     """|error: dep-syntax-error.md:3:13: invalid dependency. To fix this error, use the format `$ORGANIZATION:$ARTIFACT:$NAME`.
        |import $dep.`org.scalameta:no-version`
        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+
+  checkError(
+    "dep-syntax-error-using".tag(OnlyScala213),
+    """
+      |```scala mdoc
+      |//> using dep org.scalameta:no-version
+      |//> using dep org.scalameta::has-version:1.0.0
+      |println(42)
+      |```
+      | """.stripMargin,
+    """|error: dep-syntax-error-using.md:3:11: invalid dependency. To fix this error, use the format `$ORGANIZATION:$ARTIFACT:$NAME`.
+       |//> using dep org.scalameta:no-version
+       |          ^
        |""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
+++ b/tests/unit/src/test/scala/tests/imports/ScalacSuite.scala
@@ -5,29 +5,35 @@ import tests.markdown.Compat
 
 class ScalacSuite extends BaseMarkdownSuite {
 
-  checkError(
-    "import".tag(OnlyScala213),
-    """
-      |```scala mdoc
-      |import $scalac.`-Wunused:imports -Xfatal-warnings`
-      |import scala.util.Try
-      |println(42)
-      |```
-      |""".stripMargin,
-    """|error: No warnings can be incurred under -Werror.
-       |warning: import.md:4:1: Unused import
-       |import scala.util.Try
-       |^^^^^^^^^^^^^^^^^^^^^
-       |""".stripMargin,
-    compat = Map(
-      Compat.Scala213 ->
-        """|error: No warnings can be incurred under -Werror.
-           |warning: import.md:4:19: Unused import
-           |import scala.util.Try
-           |                  ^^^
-           |""".stripMargin
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $scalac.`-Wunused:imports -Xfatal-warnings`",
+      "using" -> "//> using option -Wunused:imports -Xfatal-warnings"
     )
   )
+    checkError(
+      s"import-$name".tag(OnlyScala213),
+      s"""
+         |```scala mdoc
+         |$importStyle
+         |import scala.util.Try
+         |println(42)
+         |```
+         |""".stripMargin,
+      s"""|error: No warnings can be incurred under -Werror.
+          |warning: import-$name.md:4:1: Unused import
+          |import scala.util.Try
+          |^^^^^^^^^^^^^^^^^^^^^
+          |""".stripMargin,
+      compat = Map(
+        Compat.Scala213 ->
+          s"""|error: No warnings can be incurred under -Werror.
+              |warning: import-$name.md:4:19: Unused import
+              |import scala.util.Try
+              |                  ^^^
+              |""".stripMargin
+      )
+    )
 
   check(
     "no-import".tag(OnlyScala213),
@@ -45,27 +51,33 @@ class ScalacSuite extends BaseMarkdownSuite {
        |""".stripMargin
   )
 
-  check(
-    "import-fail".tag(OnlyScala213),
-    """
-      |```scala mdoc
-      |import $scalac.`-Wunused:imports -Xfatal-warnings`
-      |```
-      |```scala mdoc:fail
-      |import scala.util.Try
-      |println(42)
-      |```
-      |""".stripMargin,
-    // NOTE(olafur) I'm not sure if this is the ideal behavior, this test is
-    // only to document the current behavior.
-    """|```scala
-       |import $scalac.`-Wunused:imports -Xfatal-warnings`
-       |```
-       |```scala
-       |import scala.util.Try
-       |println(42)
-       |// error: No warnings can be incurred under -Werror.
-       |```
-       |""".stripMargin
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $scalac.`-Wunused:imports -Xfatal-warnings`",
+      "using" -> "//> using option -Wunused:imports -Xfatal-warnings"
+    )
   )
+    check(
+      s"import-fail-$name".tag(OnlyScala213),
+      s"""
+         |```scala mdoc
+         |$importStyle
+         |```
+         |```scala mdoc:fail
+         |import scala.util.Try
+         |println(42)
+         |```
+         |""".stripMargin,
+      // NOTE(olafur) I'm not sure if this is the ideal behavior, this test is
+      // only to document the current behavior.
+      s"""|```scala
+          |$importStyle
+          |```
+          |```scala
+          |import scala.util.Try
+          |println(42)
+          |// error: No warnings can be incurred under -Werror.
+          |```
+          |""".stripMargin
+    )
 }

--- a/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
+++ b/tests/worksheets/src/test/scala/tests/worksheets/WorksheetSuite.scala
@@ -147,56 +147,78 @@ class WorksheetSuite extends BaseSuite {
   )
 
   checkDecorations(
-    "scalatags",
-    """|import $dep.`com.lihaoyi::scalatags:0.13.1`
+    "multi-using",
+    """|//> using dep com.lihaoyi::scalatags:0.13.1 com.lihaoyi::ujson:4.1.0
        |import scalatags.Text.all._
-       |val htmlFile = html(
-       |  body(
-       |    p("This is a big paragraph of text")
-       |  )
-       |)
+       |import ujson._
+       |
+       |println("hello")
        |""".stripMargin,
-    """|import $dep.`com.lihaoyi::scalatags:0.13.1`
+    """|//> using dep com.lihaoyi::scalatags:0.13.1 com.lihaoyi::ujson:4.1.0
        |import scalatags.Text.all._
-       |<val htmlFile = html(
-       |  body(
-       |    p("This is a big paragraph of text")
-       |  )
-       |)> // : scalatags.Text.TypedTag[String] = TypedTag( tag = "html", modifiers = List( ArraySeq( TypedTag( t...
-       |htmlFile: scalatags.Text.TypedTag[String] = TypedTag(
-       |  tag = "html",
-       |  modifiers = List(
-       |    ArraySeq(
-       |...
-       |""".stripMargin,
-    compat = Map(
-      Compat.Scala3 ->
-        """|import $dep.`com.lihaoyi::scalatags:0.13.1`
-           |import scalatags.Text.all._
-           |<val htmlFile = html(
-           |  body(
-           |    p("This is a big paragraph of text")
-           |  )
-           |)> // : TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
-           |htmlFile: TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
-           |""".stripMargin,
-      Compat.Scala212 ->
-        """|import $dep.`com.lihaoyi::scalatags:0.13.1`
-           |import scalatags.Text.all._
-           |<val htmlFile = html(
-           |  body(
-           |    p("This is a big paragraph of text")
-           |  )
-           |)> // : scalatags.Text.TypedTag[String] = TypedTag( "html", List( WrappedArray( TypedTag( "body", List( W...
-           |htmlFile: scalatags.Text.TypedTag[String] = TypedTag(
-           |  "html",
-           |  List(
-           |    WrappedArray(
-           |...
-           |""".stripMargin
-    ),
-    width = 100
+       |import ujson._
+       |
+       |<println("hello")> // hello
+       |// hello
+       |""".stripMargin
   )
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $dep.`com.lihaoyi::scalatags:0.13.1`",
+      "using" -> "//> using dep com.lihaoyi::scalatags:0.13.1"
+    )
+  )
+    checkDecorations(
+      s"scalatags-$name",
+      s"""|$importStyle
+          |import scalatags.Text.all._
+          |val htmlFile = html(
+          |  body(
+          |    p("This is a big paragraph of text")
+          |  )
+          |)
+          |""".stripMargin,
+      s"""|$importStyle
+          |import scalatags.Text.all._
+          |<val htmlFile = html(
+          |  body(
+          |    p("This is a big paragraph of text")
+          |  )
+          |)> // : scalatags.Text.TypedTag[String] = TypedTag( tag = "html", modifiers = List( ArraySeq( TypedTag( t...
+          |htmlFile: scalatags.Text.TypedTag[String] = TypedTag(
+          |  tag = "html",
+          |  modifiers = List(
+          |    ArraySeq(
+          |...
+          |""".stripMargin,
+      compat = Map(
+        Compat.Scala3 ->
+          s"""|$importStyle
+              |import scalatags.Text.all._
+              |<val htmlFile = html(
+              |  body(
+              |    p("This is a big paragraph of text")
+              |  )
+              |)> // : TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
+              |htmlFile: TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
+              |""".stripMargin,
+        Compat.Scala212 ->
+          s"""|$importStyle
+              |import scalatags.Text.all._
+              |<val htmlFile = html(
+              |  body(
+              |    p("This is a big paragraph of text")
+              |  )
+              |)> // : scalatags.Text.TypedTag[String] = TypedTag( "html", List( WrappedArray( TypedTag( "body", List( W...
+              |htmlFile: scalatags.Text.TypedTag[String] = TypedTag(
+              |  "html",
+              |  List(
+              |    WrappedArray(
+              |...
+              |""".stripMargin
+      ),
+      width = 100
+    )
 
   checkDecorations(
     "multi-mods",
@@ -449,29 +471,35 @@ class WorksheetSuite extends BaseSuite {
     )
   )
 
-  checkDecorations(
-    "fastparse".tag(SkipScala3).tag(SkipScala211),
-    """
-      |import $dep.`com.lihaoyi::fastparse:2.3.0`
-      |import fastparse._, MultiLineWhitespace._
-      |def p[_:P] = P("a")
-      |parse("a", p(_))
-      |""".stripMargin,
-    """|import $dep.`com.lihaoyi::fastparse:2.3.0`
-       |import fastparse._, MultiLineWhitespace._
-       |def p[_:P] = P("a")
-       |<parse("a", p(_))> // : Parsed[Unit] = Suc...
-       |res0: Parsed[Unit] = Success((), 1)
-       |""".stripMargin,
-    compat = Map(
-      Compat.Scala213 -> """|import $dep.`com.lihaoyi::fastparse:2.3.0`
-                            |import fastparse._, MultiLineWhitespace._
-                            |def p[_:P] = P("a")
-                            |<parse("a", p(_))> // : Parsed[Unit] = Suc...
-                            |res0: Parsed[Unit] = Success(value = (), index = 1)
-                            |""".stripMargin
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $dep.`com.lihaoyi::fastparse:2.3.0`",
+      "using" -> "//> using dependency com.lihaoyi::fastparse:2.3.0"
     )
   )
+    checkDecorations(
+      s"fastparse-$name".tag(SkipScala3).tag(SkipScala211),
+      s"""
+         |$importStyle
+         |import fastparse._, MultiLineWhitespace._
+         |def p[_:P] = P("a")
+         |parse("a", p(_))
+         |""".stripMargin,
+      s"""|$importStyle
+          |import fastparse._, MultiLineWhitespace._
+          |def p[_:P] = P("a")
+          |<parse("a", p(_))> // : Parsed[Unit] = Suc...
+          |res0: Parsed[Unit] = Success((), 1)
+          |""".stripMargin,
+      compat = Map(
+        Compat.Scala213 -> s"""|$importStyle
+                               |import fastparse._, MultiLineWhitespace._
+                               |def p[_:P] = P("a")
+                               |<parse("a", p(_))> // : Parsed[Unit] = Suc...
+                               |res0: Parsed[Unit] = Success(value = (), index = 1)
+                               |""".stripMargin
+      )
+    )
 
   checkDecorations(
     "dotty-extension-methods".tag(OnlyScala3),
@@ -531,29 +559,35 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
-  checkDecorations(
-    "dotty-imports".tag(OnlyScala3),
-    """|import $dep.`com.lihaoyi:scalatags_2.13:0.9.1`
-       |import scalatags.Text.all._
-       |val htmlFile = html(
-       |  body(
-       |    p("This is a big paragraph of text")
-       |  )
-       |)
-       |htmlFile.render
-       |""".stripMargin,
-    """|import $dep.`com.lihaoyi:scalatags_2.13:0.9.1`
-       |import scalatags.Text.all._
-       |<val htmlFile = html(
-       |  body(
-       |    p("This is a big paragraph of text")
-       |  )
-       |)> // : TypedTag[String] = <html><b...
-       |htmlFile: TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
-       |<htmlFile.render> // : String = <html><bo...
-       |res0: String = <html><body><p>This is a big paragraph of text</p></body></html>
-       |""".stripMargin
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $dep.`com.lihaoyi:scalatags_2.13:0.9.1`",
+      "using" -> "//> using dependency com.lihaoyi:scalatags_2.13:0.9.1"
+    )
   )
+    checkDecorations(
+      s"dotty-imports-$name".tag(OnlyScala3),
+      s"""|$importStyle
+          |import scalatags.Text.all._
+          |val htmlFile = html(
+          |  body(
+          |    p("This is a big paragraph of text")
+          |  )
+          |)
+          |htmlFile.render
+          |""".stripMargin,
+      s"""|$importStyle
+          |import scalatags.Text.all._
+          |<val htmlFile = html(
+          |  body(
+          |    p("This is a big paragraph of text")
+          |  )
+          |)> // : TypedTag[String] = <html><b...
+          |htmlFile: TypedTag[String] = <html><body><p>This is a big paragraph of text</p></body></html>
+          |<htmlFile.render> // : String = <html><bo...
+          |res0: String = <html><body><p>This is a big paragraph of text</p></body></html>
+          |""".stripMargin
+    )
 
   checkDecorations(
     "end-markers".tag(OnlyScala3),
@@ -573,21 +607,27 @@ class WorksheetSuite extends BaseSuite {
        |""".stripMargin
   )
 
-  checkDecorations(
-    "akka".tag(SkipScala3).tag(SkipScala211),
-    """|import $dep.`com.typesafe.akka::akka-actor:2.6.13`
-       |import akka.actor.ActorSystem
-       |
-       |implicit val system = ActorSystem("worksheet")
-       |
-       |""".stripMargin,
-    """|import $dep.`com.typesafe.akka::akka-actor:2.6.13`
-       |import akka.actor.ActorSystem
-       |
-       |<implicit val system = ActorSystem("worksheet")> // : ActorSystem = akka...
-       |system: ActorSystem = akka://worksheet
-       |""".stripMargin
+  for (
+    (name, importStyle) <- Seq(
+      "ammonite" -> "import $dep.`com.typesafe.akka::akka-actor:2.6.13`",
+      "using" -> "//> using dependency com.typesafe.akka::akka-actor:2.6.13"
+    )
   )
+    checkDecorations(
+      s"akka-$name".tag(SkipScala3).tag(SkipScala211),
+      s"""|$importStyle
+          |import akka.actor.ActorSystem
+          |
+          |implicit val system = ActorSystem("worksheet")
+          |
+          |""".stripMargin,
+      s"""|$importStyle
+          |import akka.actor.ActorSystem
+          |
+          |<implicit val system = ActorSystem("worksheet")> // : ActorSystem = akka...
+          |system: ActorSystem = akka://worksheet
+          |""".stripMargin
+    )
 
   checkDecorations(
     "placeholder",


### PR DESCRIPTION
This add using directives alongside the ammonite style imports. It would probably be much cleaner if we managed to remove the old syntax, but we need to leave them for a while for sure. We can later start deprecating them.

This also unblocks worksheets support.