### PR TITLE
chore: Skip publishing docs module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -451,6 +451,7 @@ lazy val docs = project
   .settings(
     sharedSettings,
     moduleName := "mdoc-docs",
+    publish / skip := true,
     scalaVersion := scala212,
     crossScalaVersions := List(scala212),
     publish / skip :=


### PR DESCRIPTION
I don't actually see it being used and it seems to mess with the release process.