### PR TITLE
Cross build for sbt 2.0.0-RC6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
           - "'++2.13.16 test'"
           # Minimal supported version
           - "'++3.3.6 test'"
-          - "scripted"
+          - "'++3.7.3 plugin/test'"
+          - "'++2.12.20 scripted'"
+          - "'++3.7.3 scripted'"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ addCommandAlias(
 def scala212 = "2.12.20"
 def scala213 = "2.13.16"
 def scala3 = "3.3.6"
+def scala3ForSbt = "3.7.3"
 def scala2Versions = List(scala212, scala213)
 def allScalaVersions = scala2Versions :+ scala3
 
@@ -381,8 +382,11 @@ lazy val plugin = project
     sharedSettings,
     sbtPlugin := true,
     scalaVersion := scala212,
-    pluginCrossBuild / sbtVersion := "1.5.0",
-    crossScalaVersions := List(scala212),
+    pluginCrossBuild / sbtVersion := (scalaBinaryVersion.value match {
+      case "2.12" => "1.5.0"
+      case _ => "2.0.0-RC6"
+    }),
+    crossScalaVersions := List(scala212, scala3ForSbt),
     moduleName := "sbt-mdoc",
     libraryDependencies ++= List(
       "org.jsoup" % "jsoup" % "1.12.1",

--- a/mdoc-sbt/src/main/scala-2/mdoc/MdocPluginCompat.scala
+++ b/mdoc-sbt/src/main/scala-2/mdoc/MdocPluginCompat.scala
@@ -1,0 +1,14 @@
+package mdoc
+
+import sbt._
+import sbt.Keys._
+
+trait MdocPluginCompat {
+  protected final def getClasspathFiles(
+      classpath: TaskKey[Classpath]
+  ): Def.Initialize[Task[Seq[File]]] =
+    Def.task(classpath.value.map(_.data))
+
+  protected final def fileToFileRef(file: Def.Initialize[Task[File]]): Def.Initialize[Task[File]] =
+    file
+}

--- a/mdoc-sbt/src/main/scala-3/mdoc/MdocPluginCompat.scala
+++ b/mdoc-sbt/src/main/scala-3/mdoc/MdocPluginCompat.scala
@@ -1,0 +1,21 @@
+package mdoc
+
+import sbt.*
+import sbt.Keys.*
+
+trait MdocPluginCompat {
+  export sbt.util.CacheImplicits.given
+
+  protected final def getClasspathFiles(
+      classpath: TaskKey[Classpath]
+  ): Def.Initialize[Task[Seq[File]]] =
+    Def.task {
+      val converter = fileConverter.value
+      classpath.value.map(f => converter.toPath(f.data).toFile)
+    }
+
+  protected final def fileToFileRef(
+      file: Def.Initialize[Task[File]]
+  ): Def.Initialize[Task[HashedVirtualFileRef]] =
+    Def.task(fileConverter.value.toVirtualFile(file.value.toPath))
+}

--- a/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala
@@ -14,7 +14,7 @@ import scala.sys.process.ProcessBuilder
 import mdoc.MdocPlugin.{autoImport => m}
 import scala.util.Try
 
-object DocusaurusPlugin extends AutoPlugin {
+object DocusaurusPlugin extends AutoPlugin with MdocPluginCompat {
   override def requires: Plugins = JvmPlugin && MdocPlugin
   object autoImport {
     val docusaurusProjectName =
@@ -146,13 +146,13 @@ object DocusaurusPlugin extends AutoPlugin {
         Relativize.htmlSite(out.toPath)
         out
       },
-      (Compile / packageDoc) := {
+      (Compile / packageDoc) := fileToFileRef(Def.task {
         val directory = doc.value
         val jar = target.value / "docusaurus.jar"
         val files = listJarFiles(directory.toPath)
         IO.jar(files, jar, new java.util.jar.Manifest())
         jar
-      }
+      }).value
     )
 
   private implicit class XtensionListStringProcess(command: List[String]) {

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/extra-arguments/project/build.properties
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/extra-arguments/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 1.11.7

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/extra-arguments/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/extra-arguments/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/scalac-options-dedup/project/build.properties
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/scalac-options-dedup/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 1.11.7

--- a/mdoc-sbt/src/sbt-test/sbt-mdoc/scalac-options-dedup/project/plugins.sbt
+++ b/mdoc-sbt/src/sbt-test/sbt-mdoc/scalac-options-dedup/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % sys.props("plugin.version"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,6 +19,7 @@ libraryDependencies ++= List(
   "org.jsoup" % "jsoup" % "1.12.1",
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 )
-Compile / unmanagedSourceDirectories +=
-  (ThisBuild / baseDirectory).value.getParentFile /
-    "mdoc-sbt" / "src" / "main" / "scala"
+Compile / unmanagedSourceDirectories ++= {
+  val dir = (ThisBuild / baseDirectory).value.getParentFile / "mdoc-sbt" / "src" / "main"
+  Seq(dir / "scala", dir / "scala-2")
+}


### PR DESCRIPTION
Sets up the `mdoc-sbt` project to cross build for sbt 2 and Scala 3.7.3.

The only caveat is that the `sbt-mdoc/basic` and `sbt-mdoc/scalajs-1.7` scripted tests are disabled on sbt 2 because `sbt-scalajs` doesn't yet support sbt 2. Support is tracked in https://github.com/scala-js/scala-js/issues/5238 and an initial attempt at support was attempted and described in https://github.com/sbt/sbt/issues/7698#issuecomment-2374439991.