### PR TITLE
Drop sbt-sonatype plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-
 val crossProjectV = "1.3.2"
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossProjectV)


### PR DESCRIPTION
sbt-ci-release already depends on it transitively, and the build uses none of its tasks or settings directly.