### PR TITLE
Build on JDK 17 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
       - run: ./bin/scalafmt --test
   docs:
@@ -27,7 +27,7 @@ jobs:
           node-version: "24"
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
           cache: sbt
       - uses: sbt/setup-sbt@v1
@@ -79,7 +79,7 @@ jobs:
           node-version: "24"
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
           cache: sbt
       - uses: sbt/setup-sbt@v1
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17]
+        java: [17]
         command:
           # Test legacy Scala versions, where reporting API changed
           - "'++2.12.12! testAllNonNative'" # compiler version too old for Scala Native

--- a/.github/workflows/mdoc.yml
+++ b/.github/workflows/mdoc.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "24"
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - uses: sbt/setup-sbt@v1
       - uses: olafurpg/setup-gpg@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "24"
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
           cache: sbt
       - uses: sbt/setup-sbt@v1


### PR DESCRIPTION
Scala Native and sbt-scalajs deprecate JDK < 17, so bump every setup-java to 17 and shift the test matrix from [11, 17] to [17, 21].

Scala 3 had no -release, so it implicitly emitted Java 11 bytecode on the old JDK 11 runners; pin it to -release 11 so the JDK bump does not silently raise the artifact's bytecode floor to 17.