### PR TITLE
docs: use generic OWNER/REPO URL for deploy keys

### DIFF
--- a/docs/docusaurus.md
+++ b/docs/docusaurus.md
@@ -125,8 +125,9 @@ interesting, read ahead.
 
 ### Deploy key
 
-Open the "Deploy key" menu in your project settings:
-https://github.com/scalameta/mdoc/settings/keys. Press "Add deploy key".
+Open the "Deploy key" menu in your project settings
+(`https://github.com/OWNER/REPO/settings/keys`, replacing `OWNER`/`REPO`
+with your repository). Press "Add deploy key".
 
 - `Title`: use "Docusaurus Travis".
 - `Allow write access`: check the box, this is requires since we want to write


### PR DESCRIPTION
## Summary
Follow-up to #1114 for issue #854. The GitHub Actions secrets URL is already generic; the **Deploy key** settings link on the same page still pointed at `scalameta/mdoc/settings/keys`, which 404s for readers who are not maintainers.

This change uses the same `OWNER`/`REPO` placeholder pattern for deploy keys.

## Test plan
- [ ] Confirm `docs/docusaurus.md` no longer contains `scalameta/mdoc/settings/`
- [ ] Spot-check the Docusaurus website page after publish

Closes #854.