### PR TITLE
sbt2 prep: scope the root project settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,9 +115,10 @@ inThisBuild(
   )
 )
 
-name := "mdocRoot"
-publish / skip := true
-crossScalaVersions := Nil
+LocalRootProject / name := "mdocRoot"
+LocalRootProject / publish / skip := true
+LocalRootProject / crossScalaVersions := Nil
+
 lazy val sharedSettings = List(
   scalacOptions ++= crossSetting(
     scalaVersion.value,


### PR DESCRIPTION
A bare setting in build.sbt is build-wide on sbt 2, so name, publish and crossScalaVersions say which project they mean.