### PR TITLE
Name the CI test commands as aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,14 @@ jobs:
         command:
           # Test legacy Scala versions, where reporting API changed
           - "'++2.12.12! testAllNonNative'" # compiler version too old for Scala Native
-          - "'++2.12.21 test'"
-          - "'++2.13.18 test'"
+          - "test212"
+          - "test213"
           # Minimal supported version
-          - "'++3.3.8 test'"
+          - "test33"
+          - "test38"
           - "'++3.8.4 plugin/test'"
           - "'++2.12.21 scripted'"
           - "'++3.8.4 scripted'"
-        include:
-          - java: 17
-            command: "'++3.8.4!; unit/test; worksheets/test'"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,18 @@ import scala.collection.mutable
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import scala.scalanative.build._
 
+Global / resolvers += "scala-nightlies" at
+  "https://repo.scala-lang.org/artifactory/maven-nightlies"
+
 addCommandAlias(
   "testAllNonNative",
   "interfaces/test;runtime/test;parser/test;cli/test;mdoc/test;testsInput/test;tests/test;jsdocs/test;worksheets/test;unit/test;unitJS/test;jsApi/test;jsWorker/test;js/test;"
 )
-
-Global / resolvers += "scala-nightlies" at
-  "https://repo.scala-lang.org/artifactory/maven-nightlies"
+addCommandAlias("test212", "++2.12.21 test")
+addCommandAlias("test213", "++2.13.18 test")
+addCommandAlias("test33", "++3.3.8 test")
+// the next Scala is tested where the 3.8.4 job tested it
+addCommandAlias("test38", "++3.8.4!; unit/test; worksheets/test")
 
 def scala212 = "2.12.21"
 def scala213 = "2.13.18"


### PR DESCRIPTION
CI spelled out the ++ and the task for each Scala version. The aliases carry the same commands, so what CI calls stays the same when the way to select a version changes.