### PR TITLE
Give the js tests properties of their own

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -331,6 +331,8 @@ def jsWorkerClasspath(v: String) = {
 
 def unitJSRow(v: String) = Def.settings(
   mdocJS := Some(jsdocs.js(v)),
+  // unit ships an mdoc.properties of its own, and it comes first on the test classpath
+  mdocPropertiesPrefix := "js-",
   unitRow(v),
   jsWorkerClasspath(v)
 )

--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -49,6 +49,11 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
         "If false, do not add mdoc as a library dependency this project. " +
           "Default value is true."
       )
+    val mdocPropertiesPrefix =
+      settingKey[String](
+        "Prefix for the names of the generated properties resources, so that two projects on one " +
+          "classpath do not both answer to mdoc.properties. Default value is the empty string."
+      )
     val esModuleImportJSMapFile =
       settingKey[Option[File]](
         "File containing an import map for remapping ESModules at link time. " +
@@ -90,6 +95,7 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
       mdocJSWorkerClasspath := None,
       mdocAutoDependency := true,
       mdocInternalVariables := Nil,
+      mdocPropertiesPrefix := "",
       esModuleImportJSMapFile := None,
       mdoc := Def.inputTaskDyn {
         validateSettings.value
@@ -118,7 +124,8 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
         }
       },
       (Compile / resourceGenerators) += Def.task {
-        val out = (Compile / managedResourceDirectories).value.head / "mdoc.properties"
+        val prefix = mdocPropertiesPrefix.value
+        val out = (Compile / managedResourceDirectories).value.head / s"${prefix}mdoc.properties"
         val props = new java.util.Properties()
         mdocVariables.value.foreach { case (key, value) =>
           props.put(key, value)
@@ -214,7 +221,7 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
         IO.write(props, "mdoc properties", out)
         val esVersion = props.clone().asInstanceOf[java.util.Properties]
         esVersion.put("js-module-kind", "ESModule")
-        val esOut = (Compile / managedResourceDirectories).value.head / "es.properties"
+        val esOut = (Compile / managedResourceDirectories).value.head / s"${prefix}es.properties"
         IO.write(
           esVersion,
           "mdoc esmoddule properties",

--- a/tests/unit-js/src/test/scala/tests/js/JsCliSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsCliSuite.scala
@@ -48,7 +48,14 @@ class JsCliSuite extends BaseCliSuite {
         |${suffix("index2")}
         |""".stripMargin,
     input = "index1.md",
-    extraArgs = Array("--in", "index2.md", "--out", out().toString()),
+    extraArgs = Array(
+      "--in",
+      "index2.md",
+      "--out",
+      out().toString(),
+      "--property-file-name",
+      JsTests.propertyFileName
+    ),
     includeOutputPath = { path => !path.toNIO.getFileName.toString.endsWith(".js") }
   )
 
@@ -79,7 +86,7 @@ class JsCliSuite extends BaseCliSuite {
         |<div id="mdoc-html-run0" data-mdoc-js data-mdoc-module-name="./docs/index2.md.js" ></div>
         |<script type="module" src="index2.md.js"></script>
         |<script type="module" src="mdoc.js"></script>""".stripMargin,
-    extraArgs = Array("--property-file-name", "es.properties"),
+    extraArgs = Array("--property-file-name", JsTests.esPropertyFileName),
     includeOutputPath = { path => !path.toNIO.getFileName.toString.endsWith(".js") }
   )
 
@@ -117,7 +124,7 @@ class JsCliSuite extends BaseCliSuite {
       "--cwd",
       in().syntax,
       "--property-file-name",
-      "es.properties",
+      JsTests.esPropertyFileName,
       "--import-map-path",
       Paths.get(this.getClass.getClassLoader.getResource("importmap.json").toURI).toString()
     )

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -13,9 +13,9 @@ class JsSuite extends BaseMarkdownSuite {
   // NOTE(olafur) Optimization. Cache settings to reuse the Scala.js compiler instance.
   // By default, we create new modifiers for each unit test, which is usually fast.
   override def baseSettings(resourcePropertyFileName: String): Settings = super
-    .baseSettings()
+    .baseSettings(JsTests.propertyFileName)
     .copy(
-      site = super.baseSettings().site ++ Map(
+      site = super.baseSettings(JsTests.propertyFileName).site ++ Map(
         "js-opt" -> "fast"
       )
     )

--- a/tests/unit-js/src/test/scala/tests/js/JsTests.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsTests.scala
@@ -1,6 +1,10 @@
 package tests.js
 
 object JsTests {
+  // MdocPlugin writes these for the unit-js rows; see mdocPropertiesPrefix in build.sbt
+  val propertyFileName = "js-mdoc.properties"
+  val esPropertyFileName = "js-es.properties"
+
   def suffix(name: String): String =
     s"""|<script type="text/javascript" src="$name.md.js" defer></script>
         |<script type="text/javascript" src="mdoc.js" defer></script>


### PR DESCRIPTION
unit and unit-js both enable MdocPlugin, so both generate a resource named mdoc.properties, and unit-js depends on unit. Which one the tests read depends on the order of two jars on the classpath, and unit's copy has no js-classpath in it.

MdocPlugin takes a prefix for those names now. The unit-js rows set it to js-, and the js tests name the files they read.