### PR TITLE
sbt2: switch from 1.12.13 to 2.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,12 @@ def rowsAt(task: String, v: String, extraJvm: Matrix*) = {
   onEach(task, v, jvm ++ extraJvm, Iterable(jsdocs, jswebsitedocs))
 }
 
-addCommandAlias("testAllNonNative", rowsAt("test", scala213, parser))
-addCommandAlias("test212", rowsAt("test", scala212))
-addCommandAlias("test213", rowsAt("test", scala213))
-addCommandAlias("test33", rowsAt("test", scala3))
+addCommandAlias("testAllNonNative", rowsAt("testFull", scala213, parser))
+addCommandAlias("test212", rowsAt("testFull", scala212))
+addCommandAlias("test213", rowsAt("testFull", scala213))
+addCommandAlias("test33", rowsAt("testFull", scala3))
 // the next Scala is tested where the 3.8.4 job tested it
-addCommandAlias("test38", onEach("test", scala3next, List(unit, worksheets), Nil))
+addCommandAlias("test38", onEach("testFull", scala3next, List(unit, worksheets), Nil))
 
 def scalajsBinaryVersion = "1"
 def scalajsDom = "2.0.0"
@@ -104,6 +104,8 @@ LocalRootProject / publish / skip := true
 LocalRootProject / crossScalaVersions := Nil
 
 lazy val sharedSettings = List(
+  // mdoc-interfaces is Java, so its row carries whichever Scala version the build defaults to
+  allowMismatchScala := true,
   scalacOptions ++= crossSetting(
     scalaVersion.value,
     if2 = List("-Yrangepos", "-deprecation"),
@@ -283,11 +285,18 @@ val jswebsitedocs = projectMatrix.jsPlatform(allScalaVersions)
   )
   .enablePlugins(ScalaJSPlugin)
 
+// a forked JVM takes the platform charset before Java 18, and the tests read UTF-8 sources
+def forkedTests = Def.settings(
+  Test / fork := true,
+  Test / javaOptions += "-Dfile.encoding=UTF-8"
+)
+
 lazy val worksheets = projectMatrix.allJvm()
   .in(file("tests/worksheets"))
   .settings(
     sharedSettings,
     unpublished,
+    forkedTests,
     libraryDependencies += depMunit % Test
   )
   .dependsOn(mdoc, tests)
@@ -301,6 +310,7 @@ lazy val unit = projectMatrix
   .settings(
     sharedSettings,
     unpublished,
+    forkedTests,
     Compile / unmanagedSourceDirectories ++= multiScalaDirectories("tests/unit").value,
     libraryDependencies ++= {
       if (isScala3.value) List()
@@ -376,7 +386,7 @@ lazy val plugin = project
       props.put("version", version.value)
       props.put("scalaJSVersion", scalaJSVersion)
       IO.write(props, "sbt-mdoc properties", out)
-      List(out)
+      Seq(out)
     },
     publishLocal := {
       publishLocal
@@ -388,6 +398,13 @@ lazy val plugin = project
         .value
     },
     scriptedBufferLog := false,
+    // the sbt that runs the scripted tests, not the floor a user must be on: sbt 1.5.0 ships
+    // Scala 2.12.13, which cannot read the classfiles of a current JDK
+    scriptedSbt :=
+      (scalaBinaryVersion.value match {
+        case "2.12" => "1.12.13"
+        case _ => (pluginCrossBuild / sbtVersion).value
+      }),
     scriptedLaunchOpts ++= Seq(
       "-Xmx2048M",
       s"-Dplugin.version=${version.value}"
@@ -437,16 +454,19 @@ lazy val docs = project
     crossScalaVersions := List(scala212),
     mdocAutoDependency := false,
     libraryDependencies ++= List(
-      "org.scala-sbt" % "sbt" % sbtVersion.value,
+      // the sbt the plugin is built against, not the one running this build
+      "org.scala-sbt" % "sbt" % (plugin / pluginCrossBuild / sbtVersion).value,
       "io.github.cibotech" %% "evilplot" % "0.9.2"
     ),
-    watchSources += (ThisBuild / baseDirectory).value / "docs",
+    watchSources := Def.uncached(
+      watchSources.value :+ WatchSource((ThisBuild / baseDirectory).value / "docs")
+    ),
     Global / cancelable := true,
     MdocPlugin.autoImport.mdoc := (Compile / run).evaluated,
     mdocJS := Some(jswebsitedocs.js(scala212)),
     jsWorkerClasspath(scala212),
     dependencyOverrides += {
-      "org.scala-lang.modules" %%% "scala-xml" % "2.4.0"
+      "org.scala-lang.modules" %% "scala-xml" % "2.4.0"
     },
     mdocVariables := {
       val stableVersion: String =
@@ -479,5 +499,5 @@ def localCrossPublish(versions: List[String]): Def.Initialize[Task[Unit]] = {
 val depMunit = "org.scalameta" %% "munit" % V.munit
 
 lazy val depJsDom = Def.settings(
-  libraryDependencies += "org.scala-js" %%% "scalajs-dom" % scalajsDom
+  libraryDependencies += "org.scala-js" %% "scalajs-dom" % scalajsDom
 )

--- a/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
+++ b/mdoc-sbt/src/main/scala/mdoc/MdocPlugin.scala
@@ -4,6 +4,7 @@ import java.io.File
 import sbt.Keys._
 import sbt.{_, given}
 import scala.collection.mutable.ListBuffer
+import xsbti.FileConverter
 import xsbti.VirtualFileRef
 
 object MdocPlugin extends AutoPlugin with MdocPluginCompat {
@@ -197,17 +198,9 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
         }
         props.put("in", mdocIn.value.toString)
         props.put("out", mdocOut.value.toString)
-        val converter = fileConverter.value
-        val pluginPrefix = "-Xplugin:"
         props.put(
           "scalacOptions",
-          (Compile / scalacOptions).value
-            .map { o =>
-              val withoutPrefix = o.stripPrefix(pluginPrefix)
-              if (withoutPrefix eq o) o
-              else pluginPrefix + converter.toPath(VirtualFileRef.of(withoutPrefix))
-            }
-            .mkString("\n")
+          resolvePluginPaths(fileConverter.value, (Compile / scalacOptions).value).mkString("\n")
         )
         val classpath = ListBuffer.empty[File]
         // Can't use fullClasspath.value because it introduces cyclic dependency between
@@ -297,10 +290,20 @@ object MdocPlugin extends AutoPlugin with MdocPluginCompat {
         case _: ClassNotFoundException => Def.setting(None)
       }
     }
+  // sbt 2 states a compiler plugin as ${CSR_CACHE}/..., which scalac cannot open
+  private def resolvePluginPaths(converter: FileConverter, options: Seq[String]): Seq[String] = {
+    val prefix = "-Xplugin:"
+    options.map { option =>
+      val path = option.stripPrefix(prefix)
+      if ((path eq option) || !path.startsWith("${")) option
+      else prefix + converter.toPath(VirtualFileRef.of(path))
+    }
+  }
+
   private def mdocCompileOptions(ref: Project): Def.Initialize[Task[CompileOptions]] =
     Def.task {
       CompileOptions(
-        (ref / Compile / scalacOptions).value,
+        resolvePluginPaths(fileConverter.value, (ref / Compile / scalacOptions).value),
         getClasspathFiles(ref / Compile / fullClasspath).value,
         classloadedSetting(
           ref,

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -21,8 +21,8 @@ object Extensions {
 
   }
 
-  // sbt 1 takes projectMatrix from a plugin; sbt 2 has it built in
-  type Matrix = sbt.internal.ProjectMatrix
+  // sbt 1 took projectMatrix from a plugin; sbt 2 has it built in
+  type Matrix = sbt.ProjectMatrix
 
   def scala212 = "2.12.21"
   def scala213 = "2.13.18"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=2.0.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= List(
 )
 Compile / unmanagedSourceDirectories ++= {
   val dir = (ThisBuild / baseDirectory).value.getParentFile / "mdoc-sbt" / "src" / "main"
-  Seq(dir / "scala", dir / "scala-2")
+  // the meta-build is Scala 2 on sbt 1 and Scala 3 on sbt 2, and the plugin
+  // keeps a compat shim for each
+  val variant = if (scalaBinaryVersion.value == "3") "scala-3" else "scala-2"
+  Seq(dir / "scala", dir / variant)
 }
-
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/tests/unit-js/src/test/scala/tests/js/JsCliSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsCliSuite.scala
@@ -126,7 +126,7 @@ class JsCliSuite extends BaseCliSuite {
       "--property-file-name",
       JsTests.esPropertyFileName,
       "--import-map-path",
-      Paths.get(this.getClass.getClassLoader.getResource("importmap.json").toURI).toString()
+      Resources.asPath("importmap.json").toString()
     )
     val code = mdoc.Main.process(args, new PrintStream(myStdout), in().toNIO)
     val generatedJs =

--- a/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
+++ b/tests/unit-js/src/test/scala/tests/js/JsSuite.scala
@@ -7,7 +7,6 @@ import tests.markdown.BaseMarkdownSuite
 import tests.js.JsTests.suffix
 import tests.markdown.Compat
 import scala.meta.io.AbsolutePath
-import java.nio.file.Paths
 
 class JsSuite extends BaseMarkdownSuite {
   // NOTE(olafur) Optimization. Cache settings to reuse the Scala.js compiler instance.
@@ -80,13 +79,7 @@ class JsSuite extends BaseMarkdownSuite {
     settings = {
       baseSettings().copy(
         site = baseSettings().site.updated("js-module-kind", "ESModule"),
-        importMapPath = Some(
-          AbsolutePath(
-            Paths
-              .get(this.getClass.getClassLoader.getResource("importmap.json").toURI())
-              .toAbsolutePath()
-          )
-        )
+        importMapPath = Some(AbsolutePath(Resources.asPath("importmap.json")))
       )
     }
   )

--- a/tests/unit-js/src/test/scala/tests/js/Resources.scala
+++ b/tests/unit-js/src/test/scala/tests/js/Resources.scala
@@ -1,0 +1,21 @@
+package tests.js
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+object Resources {
+
+  /** A resource as a file on disk.
+    *
+    * sbt 2 puts test resources in a jar; extract to file, to obtain Path.
+    */
+  def asPath(name: String): Path = {
+    val in = getClass.getClassLoader.getResourceAsStream(name)
+    require(in != null, s"no such resource: $name")
+    try {
+      val out = Files.createTempFile("mdoc-", "-" + name.replace('/', '-'))
+      Files.copy(in, out, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+      out.toAbsolutePath()
+    } finally in.close()
+  }
+}


### PR DESCRIPTION
%%% goes away: on sbt 2 the platform sits in the module, so %% carries it. test means testQuick, so the aliases ask for testFull. watchSources is a cached setting whose value has no JsonFormat, hence Def.uncached. A resource generator returns Seq, not List.

The test classpath carries jars rather than class directories, so the tests fork to see the project's own classes, and a resource read from a jar needs copying out before anything can open it as a file.

A compiler plugin arrives as ${CSR_CACHE}/..., which scalac cannot open, so the js options resolve those paths the way the main ones already did.

mdoc-interfaces is Java and its row carries the default Scala version, which every dependent row now has to allow. The docs ask for the sbt the plugin is built against, not the 2.0.6 running this build, which would put Scala 3 artifacts on a 2.12 classpath. And scripted's sbt is stated outright, because its default became the floor from pluginCrossBuild, which is too old to run on a current JDK.