### PR TITLE
Raise the test timeout above munit's 30 seconds

### DIFF
--- a/tests/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/tests/src/main/scala/tests/BaseSuite.scala
@@ -3,9 +3,13 @@ package tests
 import munit.FunSuite
 import munit.Location
 import munit.diff.DiffOptions
+import scala.concurrent.duration._
 import tests.markdown.Compat
 
 class BaseSuite extends FunSuite {
+  // a suite compiles and links its own input, which takes minutes on a Windows runner
+  override def munitTimeout = 3.minutes
+
   def postProcessObtained: Map[Compat.ScalaVersion, String => String] = Map.empty
   def postProcessExpected: Map[Compat.ScalaVersion, String => String] = Map.empty
   override def assertNoDiff(obtained: String, expected: String, clue: => Any)(implicit


### PR DESCRIPTION
A suite compiles and links its own input, which the Windows runner does at half the speed of Linux: JsCliSuite took 22s under sbt 1 and 44s under sbt 2 there, and JsCliSuite.basic alone crossed 30s, so munit stopped it.