### PR TITLE
Extensions: let the IDE import one Scala version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Narrowing what an IDE imports
+
+sbt builds each project of this build once per Scala version and platform. Several of those rows
+use the same source directories. Two system properties control which rows an IDE imports: the
+build sets `bspEnabled := false` on the other rows, and sbt then leaves them out of the BSP
+workspace.
+
+- `-Dide.scala=X` — sbt keeps only the rows for Scala version `X`.
+  - matches full or binary version
+  - if unspecified or empty: keep all scala versions
+    - IntelliJ only: will be forced to `2.13`; see below why IntelliJ can't load multiple versions.
+- `-Dide.platform=Y` — sbt keeps only the rows for the platforms in `Y`, a comma-separated list.
+  - matches `jvm`, `js`, or `native`
+  - if unspecified or empty: keep every platform
+
+IntelliJ cannot import the whole matrix. It puts the sources that several rows use into one module,
+and then compiles the Scala 2 and the Scala 3 sources of a project together. It starts sbt with
+`-Didea.managed=true`. If you do not set `-Dide.scala`, that property selects 2.13. To choose
+another version, add `-Dide.scala=X` under `Settings -> Build, Execution, Deployment -> Build Tools
+-> sbt -> VM parameters`, then reload the sbt project.
+
+An sbt server uses the system properties from its own command line. It ignores a property that you
+pass to a later command. Run `sbt shutdown` before you test a change to these properties from the
+shell.

--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,7 @@ lazy val depCoursierInterfaces = Def.settings(
 lazy val interfaces = project
   .in(file("mdoc-interfaces"))
   .settings(
+    ideImportJvm,
     moduleName := "mdoc-interfaces",
     autoScalaLibrary := false,
     depCoursierInterfaces,
@@ -361,6 +362,7 @@ lazy val unitJS = projectMatrix
 lazy val plugin = project
   .in(file("mdoc-sbt"))
   .settings(
+    ideImportJvm,
     sharedSettings,
     sbtPlugin := true,
     scalaVersion := scala212,
@@ -444,6 +446,7 @@ lazy val js = projectMatrix.crossJvm()
 lazy val docs = project
   .in(file("mdoc-docs"))
   .settings(
+    ideImportJvm,
     sharedSettings,
     moduleName := "mdoc-docs",
     unpublished,

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -103,24 +103,47 @@ object Extensions {
     Test / unmanagedSourceDirectories ++= roots(base, "test").value
   )
 
+  /* `bspEnabled := false` leaves a row out of the BSP workspace, so an IDE does not import it.
+   * IntelliJ can't load multiple versions, though, so force 2.13 if `ide.scala` is absent. */
+  private val ideScala = {
+    val prop = sys.props.getOrElse("ide.scala", "").trim
+    if (prop.nonEmpty) Some(prop)
+    else if (sys.props.contains("idea.managed")) Some(scala213) // this looks like IntelliJ
+    else None
+  }
+
+  // an empty set is no filter, so every platform
+  private val idePlatforms = {
+    val prop = sys.props.getOrElse("ide.platform", "").trim
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet
+  }
+
+  def ideImportFor(axes: Def.Initialize[Seq[VirtualAxis]]) = bspEnabled := ! {
+    autoScalaLibrary.value && ideScala.exists(s => s != scalaBinaryVersion.value && s != scalaVersion.value) ||
+    idePlatforms.nonEmpty && !platformOf(axes.value).exists(idePlatforms)
+  }
+
+  // a project that is not a matrix has no axes to read, and none of them leaves the JVM
+  val ideImportJvm = ideImportFor(Def.setting(Seq(VirtualAxis.jvm)))
+
   implicit class MatrixExtensions(private val self: Matrix) extends AnyVal {
     // projectMatrix names its rows after the val it is assigned to, so rows are added to the
     // receiver and never built here
     def jvmRows(versions: Iterable[String])(ss: String => Def.SettingsDefinition): Matrix =
-      versions.foldLeft(self)((m, v) => m.crossJvmRows(v)(Nil, ss(v)))
+      versions.foldLeft(sharedSetup)((m, v) => m.crossJvmRows(v)(Nil, ss(v)))
 
     def crossJvmRows(sv: String*)(axes: List[VirtualAxis], ss: Def.SettingsDefinition*): Matrix =
       self.jvmPlatform(sv, axes, ss.flatMap(_.settings))
 
     // one row per published version
-    def crossJvm(ss: Def.SettingsDefinition*): Matrix = self
-      .crossJvmRows(allScalaVersions *)(Nil, ss *)
+    def withJvm(ss: Def.SettingsDefinition*): Matrix = crossJvmRows(allScalaVersions *)(Nil, ss *)
+    def crossJvm(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withJvm(ss *)
 
-    def crossJs(ss: Def.SettingsDefinition*): Matrix = self
-      .jsPlatform(allScalaVersions, ss.flatMap(_.settings))
+    def withJs(ss: Def.SettingsDefinition*): Matrix = self.jsPlatform(allScalaVersions, ss.flatMap(_.settings))
+    def crossJs(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withJs(ss *)
 
-    def crossNative(ss: Def.SettingsDefinition*): Matrix = self
-      .nativePlatform(allScalaVersions, ss.flatMap(_.settings))
+    def withNative(ss: Def.SettingsDefinition*): Matrix = self.nativePlatform(allScalaVersions, ss.flatMap(_.settings))
+    def crossNative(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withNative(ss *)
 
     // the next Scala is tested, never published
     def jvmScala3Next(ss: Def.SettingsDefinition*): Matrix = crossJvmRows(scala3next)(
@@ -136,7 +159,9 @@ object Extensions {
       jvmScala3Next(ss(scala3next)).jvmRows(allScalaVersions)(ss)
 
     // the shared tree and each platform's own, as crossProject would read them
-    def crossAll = self.settings(unmanagedSources(self.base)).allJvm().crossJs().crossNative()
+    def crossAll: Matrix = self.settings(unmanagedSources(self.base)).allJvm().withJs().withNative()
+
+    private def sharedSetup: Matrix = self.settings(ideImportFor(virtualAxes))
   }
 
 }


### PR DESCRIPTION
The IDE imported every cell, and the result did not compile. Now it imports 2.13 on every platform: `-Dide.scala` picks the version and `-Dide.platform` picks the platforms besides the JVM.

`ide-skip-project` is IntelliJ's own key, so no plugin is needed. A row reads its platform out of `virtualAxes`, which the previous commit already made it do for its source trees. The three projects that are not matrices have no axes and never leave the JVM, so they take `ideSkipJvm`. `interfaces` sets `autoScalaLibrary := false`, and that is what tells the filter it answers for no Scala version.