### PR TITLE
Extensions: decide the IDE filter where the row is made

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ workspace.
     - IntelliJ only: will be forced to `2.13`; see below why IntelliJ can't load multiple versions.
 - `-Dide.platform=Y` — sbt keeps only the rows for the platforms in `Y`, a comma-separated list.
   - matches `jvm`, `js`, or `native`
-  - if unspecified or empty: keep every platform
+  - if unspecified: keep every platform
+  - `-Dide.platform=`, with nothing after it, keeps every platform
 
 IntelliJ cannot import the whole matrix. It puts the sources that several rows use into one module,
 and then compiles the Scala 2 and the Scala 3 sources of a project together. It starts sbt with
@@ -21,6 +22,9 @@ and then compiles the Scala 2 and the Scala 3 sources of a project together. It 
 another version, add `-Dide.scala=X` under `Settings -> Build, Execution, Deployment -> Build Tools
 -> sbt -> VM parameters`, then reload the sbt project.
 
-An sbt server uses the system properties from its own command line. It ignores a property that you
-pass to a later command. Run `sbt shutdown` before you test a change to these properties from the
-shell.
+These properties change what an IDE imports over BSP. A command-line `sbt` is not a BSP client, so
+it still sees every row and builds and tests them all.
+
+An sbt server runs with the system properties from its own command line. A later `sbt` in the same
+directory attaches to that server, so a property you pass then changes nothing. Run `sbt shutdown`
+before you test a change to these properties.

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val depCoursierInterfaces = Def.settings(
 lazy val interfaces = project
   .in(file("mdoc-interfaces"))
   .settings(
-    ideImportJvm,
+    ideSkip(VirtualAxis.jvm, ""),
     moduleName := "mdoc-interfaces",
     autoScalaLibrary := false,
     depCoursierInterfaces,
@@ -362,7 +362,7 @@ lazy val unitJS = projectMatrix
 lazy val plugin = project
   .in(file("mdoc-sbt"))
   .settings(
-    ideImportJvm,
+    ideSkip(VirtualAxis.jvm, scala212),
     sharedSettings,
     sbtPlugin := true,
     scalaVersion := scala212,
@@ -446,7 +446,7 @@ lazy val js = projectMatrix.crossJvm()
 lazy val docs = project
   .in(file("mdoc-docs"))
   .settings(
-    ideImportJvm,
+    ideSkip(VirtualAxis.jvm, scala212),
     sharedSettings,
     moduleName := "mdoc-docs",
     unpublished,

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -86,8 +86,8 @@ object Extensions {
 
   private def platformOf(axes: Seq[VirtualAxis]) = axes.collectFirst { case a: VirtualAxis.PlatformAxis => a.value }
 
-  // crossProject's layout, wired by hand: a matrix has one base directory, so a cell reads the
-  // trees its own platform names. Absent directories are harmless.
+  /* crossProject's layout, wired by hand: a matrix has one base directory, so a cell reads the
+   * trees its own platform names. Absent directories are harmless. */
   def roots(base: File, cfg: String) = Def.setting(platformOf(virtualAxes.value).fold(Seq.empty[File]) { platform =>
     val variants = "scala" :: scalaVersionDirs(scalaVersion.value)
     // a matrix base may be relative, and a relative source root resolves against the wrong directory
@@ -112,44 +112,44 @@ object Extensions {
     else None
   }
 
+  // this build exposes every platform; one that does not names its own set
+  private val defaultPlatforms = Set.empty[String]
+
   // an empty set is no filter, so every platform
-  private val idePlatforms = {
-    val prop = sys.props.getOrElse("ide.platform", "").trim
-    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet
-  }
+  private val idePlatforms = sys.props.get("ide.platform")
+    .fold(defaultPlatforms)(_.split(',').map(_.trim).filter(_.nonEmpty).toSet)
 
-  def ideImportFor(axes: Def.Initialize[Seq[VirtualAxis]]) = bspEnabled := ! {
-    autoScalaLibrary.value && ideScala.exists(s => s != scalaBinaryVersion.value && s != scalaVersion.value) ||
-    idePlatforms.nonEmpty && !platformOf(axes.value).exists(idePlatforms)
+  // only ever disables a row, so it never overrides another setting
+  def ideSkip(platform: VirtualAxis.PlatformAxis, version: String): Seq[Setting[?]] = {
+    val skip = idePlatforms.nonEmpty && !idePlatforms(platform.value) ||
+      version.nonEmpty && ideScala.exists(s => s != version && s != CrossVersion.binaryScalaVersion(version))
+    if (skip) Seq(bspEnabled := false) else Nil
   }
-
-  // a project that is not a matrix has no axes to read, and none of them leaves the JVM
-  val ideImportJvm = ideImportFor(Def.setting(Seq(VirtualAxis.jvm)))
 
   implicit class MatrixExtensions(private val self: Matrix) extends AnyVal {
-    // projectMatrix names its rows after the val it is assigned to, so rows are added to the
-    // receiver and never built here
+    // projectMatrix names a row after the val it is assigned to, so it arrives as the receiver
     def jvmRows(versions: Iterable[String])(ss: String => Def.SettingsDefinition): Matrix =
-      versions.foldLeft(sharedSetup)((m, v) => m.crossJvmRows(v)(Nil, ss(v)))
+      versions.foldLeft(self)((m, v) => m.crossJvmRows(v)(Nil, ss(v)))
 
-    def crossJvmRows(sv: String*)(axes: List[VirtualAxis], ss: Def.SettingsDefinition*): Matrix =
-      self.jvmPlatform(sv, axes, ss.flatMap(_.settings))
+    // one row at a time, so each one knows the version it is built for
+    def crossJvmRows(sv: String*)(axes: List[VirtualAxis], ss: Def.SettingsDefinition*): Matrix = sv
+      .foldLeft(self)((m, v) => m.jvmPlatform(Seq(v), axes, ss.flatMap(_.settings) ++ ideSkip(VirtualAxis.jvm, v)))
 
     // one row per published version
     def withJvm(ss: Def.SettingsDefinition*): Matrix = crossJvmRows(allScalaVersions *)(Nil, ss *)
-    def crossJvm(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withJvm(ss *)
+    def crossJvm(ss: Def.SettingsDefinition*): Matrix = self.withJvm(ss *)
 
-    def withJs(ss: Def.SettingsDefinition*): Matrix = self.jsPlatform(allScalaVersions, ss.flatMap(_.settings))
-    def crossJs(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withJs(ss *)
+    def withJs(ss: Def.SettingsDefinition*): Matrix = allScalaVersions
+      .foldLeft(self)((m, v) => m.jsPlatform(Seq(v), ss.flatMap(_.settings) ++ ideSkip(VirtualAxis.js, v)))
+    def crossJs(ss: Def.SettingsDefinition*): Matrix = self.withJs(ss *)
 
-    def withNative(ss: Def.SettingsDefinition*): Matrix = self.nativePlatform(allScalaVersions, ss.flatMap(_.settings))
-    def crossNative(ss: Def.SettingsDefinition*): Matrix = sharedSetup.withNative(ss *)
+    def withNative(ss: Def.SettingsDefinition*): Matrix = allScalaVersions
+      .foldLeft(self)((m, v) => m.nativePlatform(Seq(v), ss.flatMap(_.settings) ++ ideSkip(VirtualAxis.native, v)))
+    def crossNative(ss: Def.SettingsDefinition*): Matrix = self.withNative(ss *)
 
     // the next Scala is tested, never published
-    def jvmScala3Next(ss: Def.SettingsDefinition*): Matrix = crossJvmRows(scala3next)(
-      List(VirtualAxis.scalaPartialVersion(scala3next)),
-      unpublished ++ ss *
-    )
+    def jvmScala3Next(ss: Def.SettingsDefinition*): Matrix =
+      crossJvmRows(scala3next)(List(VirtualAxis.scalaPartialVersion(scala3next)), unpublished ++ ss *)
 
     // a row per published version, and one for the next Scala
     def allJvm(ss: Def.SettingsDefinition*): Matrix = self.crossJvm(ss *).jvmScala3Next(ss *)
@@ -161,7 +161,6 @@ object Extensions {
     // the shared tree and each platform's own, as crossProject would read them
     def crossAll: Matrix = self.settings(unmanagedSources(self.base)).allJvm().withJs().withNative()
 
-    private def sharedSetup: Matrix = self.settings(ideImportFor(virtualAxes))
   }
 
 }


### PR DESCRIPTION
A follow-up to #1153, and the last of a set that gives scalafmt, metaconfig, scalameta, mdoc, munit and munit-scalacheck the same filter.

`ideImportFor` read the row's platform and version out of settings, so it answered for every row, and `true` was as much an answer as `false`. A filter that can enable overrules a build that turns BSP off for a platform of its own, so its position in the settings mattered.

The filter now decides where the row is made, from the platform and the version that helper already names, and contributes `bspEnabled := false` or nothing at all. `crossJvmRows`, `withJs` and `withNative` add one row per Scala version to make the version available, and a project that is not a matrix names its own at the call site. `mdoc-interfaces` carries no Scala version and passes `""`.

`defaultPlatforms` is the set the filter starts from, named by the build, and `-Dide.platform` replaces it. This build leaves it empty, so every platform is imported.

*- Claude (on behalf of Albert)*
